### PR TITLE
fix(macos): isolate and gate onboarding acceptance

### DIFF
--- a/tools/macos-acceptance/CLAUDE.md
+++ b/tools/macos-acceptance/CLAUDE.md
@@ -2,9 +2,9 @@
 > L2 | 父级: ../CLAUDE.md
 
 成员清单
-acceptance_harness.js: macOS 定向 live matrix/v6 的唯一编排器；要求 producer 与产品来自同一 canonical repo，以现场 `sw_vers` 的 product/build identity、target contract/预期 executable SHA-256 绑定入口，并在每次 deep-sign stage 后把实际 executable/Qt runtime 与 21 次产品操作、48 个逻辑点、exact native-window 截图及同机人工 seal 逐层闭合。
+acceptance_harness.js: macOS 定向 live matrix/v6 的唯一编排器；要求 producer 与产品来自同一 canonical repo，以现场 `sw_vers` 的 product/build identity、target contract/预期 executable SHA-256 绑定入口，用 `CFFIXED_USER_HOME` 把 Foundation/Cavalry profile 限定到逐运行 session，并在每次 deep-sign stage 后把实际 executable/Qt runtime 与 21 次产品操作、48 个逻辑点、exact native-window 截图及同机人工 seal 逐层闭合。
 artifact_identity.js: 证据身份原语；统一源码/记录/截图与 Mach-O 的 SHA-256、bytes、架构、UUID 和签名读取，保证 matrix 与 seal 不分叉计算。
-build_acceptance_v2.sh: 原生 driver/helper 的无污染构建边界；compile-only 只接受 target contract 对应的 Qt 6.6.3 与仓库外空输出，live 构建另要求 `/Applications` 外且 runtime Qt 同版的 clone，两种模式都不启动 Cavalry。
+build_acceptance_v2.sh: 原生 driver/helper 的无污染构建边界；compile-only 只接受 target contract 对应的 Qt 6.6.3 public/CorePrivate headers 与仓库外空输出，live 构建另要求 `/Applications` 外且 runtime Qt 同版的 clone，两种模式都不启动 Cavalry。
 check_contract.test.js: 跨平台静态合同；锁定 tracked source closure、GEB、800 行上限、host 缺失/篡改拒绝、真实媒体、exact-window 协议及 live 参数失败关闭，不冒充现场 PASS。
 host_identity.js: live-only host OS 身份边界；固定调用 `/usr/bin/sw_vers` 采集 `productVersion`/`buildVersion`，以 exact-key schema 校验并要求人工 seal 与 matrix 同机，compile-only 不调用。
 path_safety.js: 验收器的纯文件系统安全层；在写入/改权前统一拒绝 symlink 目标、真实路径越界及 repo/clone 内 session。

--- a/tools/macos-acceptance/acceptance_harness.js
+++ b/tools/macos-acceptance/acceptance_harness.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 冻结同一 canonical repo 的产品/验收源码、现场 sw_vers host 身份、target contract、预期 executable SHA-256、fresh disposable Cavalry 2.7.2 clone 与 Qt 6.6.3 SDK/runtime。
- * [OUTPUT]: 从冻结源码构建 product injector 后，生成绑定 machine.host、逐语言 executable/Qt runtime stage 的 21 次产品操作、48 个逻辑表面及 exact-window OS 截图只读 session。
- * [POS]: acceptance-v2 的最小编排器；只做定向 Guide staging、单次同源构建、ready→截图→ack、身份和清理。
+ * [OUTPUT]: 从冻结源码构建 product injector 后，在 CFFIXED_USER_HOME 隔离的逐运行 profile 中生成绑定 machine.host、逐语言 executable/Qt runtime stage 的 21 次产品操作、48 个逻辑表面及 exact-window OS 截图只读 session。
+ * [POS]: acceptance-v2 的最小编排器；只做定向 Guide staging、单次同源构建、Foundation 用户目录隔离、ready→截图→ack、身份和清理。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 'use strict';
@@ -496,7 +496,8 @@ function runScenario(context) {
   const driver = MAIN_SCENARIOS.has(scenario) ? tools.main : tools.supplemental;
   const env = {
     ...process.env,
-    HOME: home, TMPDIR: temporary, CAVALRY_I18N_PROFILE_DIR: home,
+    HOME: home, CFFIXED_USER_HOME: home, TMPDIR: temporary,
+    CAVALRY_I18N_PROFILE_DIR: home,
     CAVALRY_I18N_RUN_UUID: uuid, CAVALRY_I18N_LANG: language,
     CAVALRY_I18N_ACCEPTANCE_SCENARIO: scenario,
     CAVALRY_I18N_SUPPLEMENTAL_SCENARIO: scenario,

--- a/tools/macos-acceptance/build_acceptance_v2.sh
+++ b/tools/macos-acceptance/build_acceptance_v2.sh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# [INPUT]: 依赖同源 repo-root 的 Cavalry/Qt target contract、Qt 6.6.3、仓库内 driver/helper 源码与系统 macOS frameworks；live 构建另要求显式 disposable Cavalry.app
+# [INPUT]: 依赖同源 repo-root 的 Cavalry/Qt target contract、Qt 6.6.3 public/CorePrivate headers、仓库内 driver/helper 源码与系统 macOS frameworks；live 构建另要求显式 disposable Cavalry.app
 # [OUTPUT]: 向显式仓库外空目录生成并 ad-hoc 签名两枚验收 dylib 与 exact-window helper；live 构建另验证 clone runtime Qt 与真实媒体，CI compile-only 不依赖 vendor app/ffprobe
 # [POS]: macos-acceptance 的唯一原生构建边界；compile-only 只证明 producer 可链接，live 构建也不启动或修改 /Applications/Cavalry.app
 # [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
@@ -46,7 +46,10 @@ if [[ -e "$out" ]]; then
 else
   mkdir -m 700 "$out"
 fi
-common=(-dynamiclib -std=c++17 -fobjc-arc -I"$qt/include" -F"$qt/lib" "${vendor_frameworks[@]}" -framework QtCore -framework QtGui -framework QtWidgets -framework Foundation -framework AppKit -framework QuartzCore -Wl,-rpath,@loader_path)
+qt_private="$qt/lib/QtCore.framework/Versions/A/Headers/$expected_qt"
+qt_core_headers="$qt/lib/QtCore.framework/Versions/A/Headers"
+[[ -f "$qt_private/QtCore/private/qobject_p.h" ]] || { print -u2 'Qt CorePrivate qobject_p.h is required';exit 64; }
+common=(-dynamiclib -std=c++17 -fobjc-arc -I"$qt/include" -I"$qt_core_headers" -I"$qt_private" -I"$qt_private/QtCore" -F"$qt/lib" "${vendor_frameworks[@]}" -framework QtCore -framework QtGui -framework QtWidgets -framework Foundation -framework AppKit -framework QuartzCore -Wl,-rpath,@loader_path)
 clang++ "${common[@]}" "$root/drivers/macos_main_acceptance_driver.mm" -o "$out/macos_main_acceptance_driver.dylib"
 clang++ "${common[@]}" "$root/drivers/macos_supplemental_acceptance_driver.mm" -o "$out/macos_supplemental_acceptance_driver.dylib"
 swiftc "$root/helpers/cgwindow_exact.swift" -o "$out/cgwindow_exact"

--- a/tools/macos-acceptance/check_contract.test.js
+++ b/tools/macos-acceptance/check_contract.test.js
@@ -108,6 +108,7 @@ test('harness freezes the real source closure and exact-window evidence protocol
 
 test('onboarding polling stays inside the Qt event loop', () => {
   const driver = read('drivers/macos_supplemental_acceptance_driver.mm');
+  const trigger = read('drivers/macos_supplemental_onboarding_trigger.inc');
   const start = driver.indexOf('void processOnboarding()');
   const end = driver.indexOf('\nQJsonObject diagnosticsJson', start);
   assert.ok(start >= 0 && end > start, 'onboarding state machine must remain inspectable');
@@ -117,6 +118,16 @@ test('onboarding polling stays inside the Qt event loop', () => {
     'all onboarding polls and transitions must use Qt timers',
   );
   assert.doesNotMatch(stateMachine, /dispatch_after|dispatch_get_main_queue/);
+  for (const literal of [
+    'armWorkspaceResetModalPoll()',
+    'NSModalPanelRunLoopMode',
+    'className(widget) == QStringLiteral("PopOverView")',
+    'onboardingStep(widget) == 0',
+    'buttons.size() == 2',
+    'ONBOARDING_RESET_PROMPT accepted',
+  ]) {
+    assert.ok(trigger.includes(literal), `missing reset-prompt contract: ${literal}`);
+  }
 });
 
 test('live matrix host identity is collected from fixed sw_vers and fails closed on omission or tampering', () => {

--- a/tools/macos-acceptance/check_contract.test.js
+++ b/tools/macos-acceptance/check_contract.test.js
@@ -104,9 +104,10 @@ test('harness freezes the real source closure and exact-window evidence protocol
   assert.doesNotMatch(harness, /cgwindow_all|dynamic-proof-two\.mp4/);
   assert.match(harness, /host, repository, target/);
   assert.match(harness, /assertSameHostIdentity\(validateHostIdentity\(machine\.host\), collectMacHostIdentity\(\)\)/);
+  assert.match(harness, /HOME: home, CFFIXED_USER_HOME: home, TMPDIR: temporary/);
 });
 
-test('onboarding polling stays inside the Qt event loop', () => {
+test('onboarding uses the exact manager and keeps polling inside Qt', () => {
   const driver = read('drivers/macos_supplemental_acceptance_driver.mm');
   const trigger = read('drivers/macos_supplemental_onboarding_trigger.inc');
   const start = driver.indexOf('void processOnboarding()');
@@ -119,15 +120,34 @@ test('onboarding polling stays inside the Qt event loop', () => {
   );
   assert.doesNotMatch(stateMachine, /dispatch_after|dispatch_get_main_queue/);
   for (const literal of [
-    'armWorkspaceResetModalPoll()',
-    'NSModalPanelRunLoopMode',
-    'className(widget) == QStringLiteral("PopOverView")',
-    'onboardingStep(widget) == 0',
-    'buttons.size() == 2',
+    'kOnboardingManagerGetterSymbol',
+    '"_ZN3Gui17onboardingManagerEv"',
+    'kShowGuideSymbol',
+    'kGlobalWidgetTagRegistrySymbol',
+    'kFindTaggedWidgetSymbol',
+    '"viewport", "sceneTree", "attributeEditor", "timeline"',
+    '"projectAssets"',
+    'ONBOARDING_WORKSPACE_READY tags=5 stableTicks=5',
+    'kShowGuidesActionObjectName',
+    'runtimeClass == QString::fromLatin1(kGuiClass)',
+    'className(manager) != QString::fromLatin1(kOnboardingManagerClass)',
+    'QObjectPrivate::get(choice)->receiverList',
+    'SIGNAL(guideSelected(std::string))',
+    'parameters.front() == QByteArrayLiteral("std::string")',
+    'guideSelected.invoke(choice, Qt::DirectConnection',
+    'class WorkspaceResetEventFilter final',
+    '"了解", "キャンセル"',
+    'className(root) != QStringLiteral("QMessageBox")',
+    'qobject_cast<QAbstractButton *>(widget)',
     'ONBOARDING_RESET_PROMPT accepted',
+    'QMetaObject::invokeMethod(confirm, "click", Qt::QueuedConnection)',
+    'std::string("firstLaunch")',
   ]) {
-    assert.ok(trigger.includes(literal), `missing reset-prompt contract: ${literal}`);
+    assert.ok(trigger.includes(literal), `missing direct-manager contract: ${literal}`);
   }
+  assert.ok(stateMachine.includes('onboardingWorkspaceReady(&rejected)'));
+  assert.match(driver, /#include <QtCore\/private\/qobject_p\.h>/);
+  assert.doesNotMatch(trigger, /OnboardingChoiceView13guideSelected|triggerGuideInNativeMenu|NSTimer|dispatch_after/);
 });
 
 test('live matrix host identity is collected from fixed sw_vers and fails closed on omission or tampering', () => {

--- a/tools/macos-acceptance/check_contract.test.js
+++ b/tools/macos-acceptance/check_contract.test.js
@@ -106,6 +106,19 @@ test('harness freezes the real source closure and exact-window evidence protocol
   assert.match(harness, /assertSameHostIdentity\(validateHostIdentity\(machine\.host\), collectMacHostIdentity\(\)\)/);
 });
 
+test('onboarding polling stays inside the Qt event loop', () => {
+  const driver = read('drivers/macos_supplemental_acceptance_driver.mm');
+  const start = driver.indexOf('void processOnboarding()');
+  const end = driver.indexOf('\nQJsonObject diagnosticsJson', start);
+  assert.ok(start >= 0 && end > start, 'onboarding state machine must remain inspectable');
+  const stateMachine = driver.slice(start, end);
+  assert.ok(
+    (stateMachine.match(/QTimer::singleShot\(\s*100,\s*qApp/g) || []).length >= 3,
+    'all onboarding polls and transitions must use Qt timers',
+  );
+  assert.doesNotMatch(stateMachine, /dispatch_after|dispatch_get_main_queue/);
+});
+
 test('live matrix host identity is collected from fixed sw_vers and fails closed on omission or tampering', () => {
   const calls = [];
   const spawn = (file, args) => {

--- a/tools/macos-acceptance/drivers/CLAUDE.md
+++ b/tools/macos-acceptance/drivers/CLAUDE.md
@@ -10,7 +10,7 @@ macos_main_save.inc: 从 ColorWindow 当前语言 Generator 页打开 owner-scop
 macos_main_save_replace.inc: 用冻结双 stem fixture 驱动 Assets Drop、Replace 与 Create 动态模板。
 macos_main_search_tag.inc: 以目标控件有界就绪驱动 Search、Add Layer、Scene Statistics、Add Tag 与 Assign Tag 的真实 owner 表面，并以同窗 GroupButton 内唯一可见 Update 标签阻断相邻翻译回归。
 macos_main_tracking.inc: 从唯一新增 MP4 素材行推进 Scene、Tracking 设置与向前跟踪对话框。
-macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动和终态编排。
+macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动；以 Qt timer 穿过 chooser 嵌套事件循环并编排终态。
 macos_supplemental_capture.inc: supplemental 场景不阻塞产品主线程的 write-once ready/ack 截图事务。
 macos_supplemental_onboarding_trigger.inc: 通过真实 Guide QAction、OnboardingChoiceView 与 firstLaunch signal 打开产品引导。
 

--- a/tools/macos-acceptance/drivers/CLAUDE.md
+++ b/tools/macos-acceptance/drivers/CLAUDE.md
@@ -10,8 +10,8 @@ macos_main_save.inc: 从 ColorWindow 当前语言 Generator 页打开 owner-scop
 macos_main_save_replace.inc: 用冻结双 stem fixture 驱动 Assets Drop、Replace 与 Create 动态模板。
 macos_main_search_tag.inc: 以目标控件有界就绪驱动 Search、Add Layer、Scene Statistics、Add Tag 与 Assign Tag 的真实 owner 表面，并以同窗 GroupButton 内唯一可见 Update 标签阻断相邻翻译回归。
 macos_main_tracking.inc: 从唯一新增 MP4 素材行推进 Scene、Tracking 设置与向前跟踪对话框。
-macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动；以 Qt timer 穿过 chooser 嵌套事件循环并编排终态。
+macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动；以 Qt/AppKit mode-aware timer 穿过 chooser 与同步 modal，并编排终态。
 macos_supplemental_capture.inc: supplemental 场景不阻塞产品主线程的 write-once ready/ack 截图事务。
-macos_supplemental_onboarding_trigger.inc: 通过真实 Guide QAction、OnboardingChoiceView 与 firstLaunch signal 打开产品引导。
+macos_supplemental_onboarding_trigger.inc: 通过真实 Guide QAction、OnboardingChoiceView 与 firstLaunch signal 打开产品引导；仅对三语 title/body/buttons 精确匹配的 workspace reset PopOverView 执行确认，未知提示失败关闭。
 
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md

--- a/tools/macos-acceptance/drivers/CLAUDE.md
+++ b/tools/macos-acceptance/drivers/CLAUDE.md
@@ -10,8 +10,8 @@ macos_main_save.inc: 从 ColorWindow 当前语言 Generator 页打开 owner-scop
 macos_main_save_replace.inc: 用冻结双 stem fixture 驱动 Assets Drop、Replace 与 Create 动态模板。
 macos_main_search_tag.inc: 以目标控件有界就绪驱动 Search、Add Layer、Scene Statistics、Add Tag 与 Assign Tag 的真实 owner 表面，并以同窗 GroupButton 内唯一可见 Update 标签阻断相邻翻译回归。
 macos_main_tracking.inc: 从唯一新增 MP4 素材行推进 Scene、Tracking 设置与向前跟踪对话框。
-macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动；以 Qt/AppKit mode-aware timer 穿过 chooser 与同步 modal，并编排终态。
+macos_supplemental_acceptance_driver.mm: Onboarding 五步与 Transform 五条自绘 action 的补充语义驱动；先以产品 WidgetTagRegistry 证明五枚必需 workspace tag 连续稳定，再以 Qt 6.6.3 CorePrivate receiver identity 取得唯一 manager，并用 Qt timer 推进真实 guide 与终态。
 macos_supplemental_capture.inc: supplemental 场景不阻塞产品主线程的 write-once ready/ack 截图事务。
-macos_supplemental_onboarding_trigger.inc: 通过真实 Guide QAction、OnboardingChoiceView 与 firstLaunch signal 打开产品引导；仅对三语 title/body/buttons 精确匹配的 workspace reset PopOverView 执行确认，未知提示失败关闭。
+macos_supplemental_onboarding_trigger.inc: 优先从对象图/Gui getter 解析 manager，必要时打开真实 chooser、验证 guideSelected 的唯一 manager receiver 并调用其精确 std::string signal；主线程 event filter 精确匹配三语 reset prompt 后驱动真实 Button。
 
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md

--- a/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
+++ b/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 完整 Qt 对象图中的 OnboardingManager、含嵌套 chooser 的 Qt 事件循环、真实 PopOverView/catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
- * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及由 Qt timer 持续推进且不阻塞产品事件循环的异步 ACK 终态。
- * [POS]: acceptance-v2 补充驱动；firstLaunch 从真实产品语义触发，状态机穿过 chooser 嵌套循环，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
+ * [INPUT]: 完整 Qt 对象图中的 OnboardingManager、含 chooser/reset PopOverView 的嵌套产品事件循环、真实 guide catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
+ * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及由 Qt/AppKit mode-aware timer 持续推进且不阻塞产品事件循环的异步 ACK 终态。
+ * [POS]: acceptance-v2 补充驱动；firstLaunch 从真实产品语义触发，状态机精确处理可选 workspace reset 后穿过嵌套循环，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 #import <AppKit/AppKit.h>
@@ -354,6 +354,7 @@ void processOnboarding() {
     QTimer::singleShot(100, qApp, [] { processOnboarding(); });
     return;
   }
+  disarmWorkspaceResetModalPoll();
   const int step = onboardingStep(root);
   const int expectedStep = gOnboardingResults.size() + 1;
   if (step != expectedStep) {

--- a/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
+++ b/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 完整 Qt 对象图中的 OnboardingManager、Qt 事件循环、真实 PopOverView/catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
- * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及不阻塞产品事件循环的异步 ACK 终态。
- * [POS]: acceptance-v2 补充驱动；firstLaunch 从真实 manager 语义触发，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
+ * [INPUT]: 完整 Qt 对象图中的 OnboardingManager、含嵌套 chooser 的 Qt 事件循环、真实 PopOverView/catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
+ * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及由 Qt timer 持续推进且不阻塞产品事件循环的异步 ACK 终态。
+ * [POS]: acceptance-v2 补充驱动；firstLaunch 从真实产品语义触发，状态机穿过 chooser 嵌套循环，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 #import <AppKit/AppKit.h>
@@ -351,16 +351,14 @@ void processOnboarding() {
         return;
       }
     }
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC),
-                   dispatch_get_main_queue(), ^{ processOnboarding(); });
+    QTimer::singleShot(100, qApp, [] { processOnboarding(); });
     return;
   }
   const int step = onboardingStep(root);
   const int expectedStep = gOnboardingResults.size() + 1;
   if (step != expectedStep) {
     if (step == expectedStep - 1 && ++gTransitionAttempts <= 80) {
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC),
-                     dispatch_get_main_queue(), ^{ processOnboarding(); });
+      QTimer::singleShot(100, qApp, [] { processOnboarding(); });
       return;
     }
     markDone(QStringLiteral("ERROR onboarding sequence expected=%1 actual=%2")

--- a/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
+++ b/tools/macos-acceptance/drivers/macos_supplemental_acceptance_driver.mm
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 完整 Qt 对象图中的 OnboardingManager、含 chooser/reset PopOverView 的嵌套产品事件循环、真实 guide catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
- * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及由 Qt/AppKit mode-aware timer 持续推进且不阻塞产品事件循环的异步 ACK 终态。
- * [POS]: acceptance-v2 补充驱动；firstLaunch 从真实产品语义触发，状态机精确处理可选 workspace reset 后穿过嵌套循环，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
+ * [INPUT]: 完整 Qt 对象图、Qt 6.6.3 CorePrivate receiver identity、产品 WidgetTagRegistry、真实 guide catalog、Transform Tool/Viewport 与产品诊断 C ABI，以及 harness 逐表面截图 ACK。
+ * [OUTPUT]: Onboarding 五步和 Transform 五条自绘 action 的 write-once 像素、拓扑、诊断，以及在五枚必需 widget tag 稳定后由 nested-loop event filter/Qt timer 推进且不阻塞产品事件循环的异步 ACK 终态。
+ * [POS]: acceptance-v2 补充驱动；firstLaunch 只在真实 workspace 注册完成后由 chooser receiver 绑定精确 manager ABI，reset prompt 只接受三语严格拓扑，UI 可见性由控件/像素证明，自绘语义由逐 source 增量证明。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 #import <AppKit/AppKit.h>
@@ -14,11 +14,13 @@
 #include <QtCore/qjsonarray.h>
 #include <QtCore/qjsondocument.h>
 #include <QtCore/qjsonobject.h>
+#include <QtCore/qmetaobject.h>
 #include <QtCore/qpointer.h>
 #include <QtCore/qregularexpression.h>
 #include <QtCore/qset.h>
 #include <QtCore/qtextstream.h>
 #include <QtCore/qtimer.h>
+#include <QtCore/private/qobject_p.h>
 #include <QtGui/qcursor.h>
 #include <QtGui/qevent.h>
 #include <QtGui/qtextdocument.h>
@@ -325,22 +327,15 @@ void processOnboarding() {
         return;
       }
     } else {
-      if (!gTriggerAttempted && gGuideChooserOpened)
-        gTriggerAttempted = triggerFirstLaunchFromChoiceView();
-      if (!gTriggerAttempted && !gGuideChooserOpened) {
-        gTriggerAttempted = triggerFirstLaunchGuide();
-        if (!gTriggerAttempted) {
-          const bool nativeTriggered =
-              triggerGuideInNativeMenu([NSApp mainMenu]);
-          const bool qtTriggered =
-              nativeTriggered ? false : triggerGuideInQtActions();
-          gGuideChooserOpened = qtTriggered || nativeTriggered;
-          appendLog(
-              QStringLiteral(
-                  "ONBOARDING_TRIGGER chooser qt=%1 native=%2")
-                  .arg(qtTriggered)
-                  .arg(nativeTriggered));
+      if (!gTriggerAttempted) {
+        bool rejected = false;
+        if (!onboardingWorkspaceReady(&rejected)) {
+          if (!rejected)
+            QTimer::singleShot(100, qApp, [] { processOnboarding(); });
+          return;
         }
+        gTriggerAttempted = triggerFirstLaunchGuide(&rejected);
+        if (rejected) return;
       }
       if (++gFindAttempts > 80) {
         markDone(gTriggerAttempted
@@ -354,7 +349,6 @@ void processOnboarding() {
     QTimer::singleShot(100, qApp, [] { processOnboarding(); });
     return;
   }
-  disarmWorkspaceResetModalPoll();
   const int step = onboardingStep(root);
   const int expectedStep = gOnboardingResults.size() + 1;
   if (step != expectedStep) {

--- a/tools/macos-acceptance/drivers/macos_supplemental_onboarding_trigger.inc
+++ b/tools/macos-acceptance/drivers/macos_supplemental_onboarding_trigger.inc
@@ -1,19 +1,79 @@
 /**
- * [INPUT]: Qt 完整对象图、AppKit modal run-loop mode、Qt/native 菜单、可选 reset PopOverView、OnboardingChoiceView 与 Cavalry 2.7.2 的 onboarding C++ ABI。
- * [OUTPUT]: 通过 manager、真实入门指南菜单或 choice signal 语义触发 firstLaunch guide，并只在精确匹配本地化 reset-workspace 对话框时确认默认布局。
- * [POS]: supplemental onboarding 的入口解析器；用 mode-aware timer 穿过同步产品弹窗后打开真实 guide，并对任何未知 modal 拓扑失败关闭，不构造验收 UI。
+ * [INPUT]: Qt 完整对象图、CorePrivate signal receiver identity、产品 WidgetTagRegistry，以及 Cavalry 2.7.2 导出的 onboarding C++ ABI。
+ * [OUTPUT]: 在 five-tag workspace 连续稳定后，经直接对象、Gui getter 或真实 chooser 的唯一 signal receiver 精确解析 manager，以产品 guideSelected/showGuide 语义触发 firstLaunch，并在嵌套事件循环内精确确认 workspace reset；同时提供内容拓扑诊断。
+ * [POS]: supplemental onboarding 的入口与就绪边界；先证明 guide 所需真实控件已注册，再优先让 chooser signal 完成自身生命周期，reset prompt 由主线程 event filter 驱动真实 Button，不构造验收 UI。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
-bool isGuideActionText(QString title) {
-  title.remove(QLatin1Char('&'));
-  title = title.trimmed();
-  return title == QStringLiteral("Getting Started Guides") ||
-         title == QStringLiteral("入门指南") ||
-         title == QStringLiteral("入門指南") ||
-         title == QStringLiteral("スタートガイド");
-}
+constexpr auto kOnboardingManagerClass = "onboarding::OnboardingManager";
+constexpr auto kOnboardingChoiceClass = "onboarding::OnboardingChoiceView";
+constexpr auto kGuiClass = "Gui";
+constexpr auto kShowGuidesActionObjectName = "showGuides";
+constexpr auto kOnboardingManagerGetterSymbol =
+    "_ZN3Gui17onboardingManagerEv";
+constexpr auto kShowGuideSymbol =
+    "_ZN10onboarding17OnboardingManager9showGuideERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
+constexpr auto kGlobalWidgetTagRegistrySymbol =
+    "_ZN10onboarding23globalWidgetTagRegistryEv";
+constexpr auto kFindTaggedWidgetSymbol =
+    "_ZNK10onboarding17WidgetTagRegistry10findWidgetERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
 
-enum class WorkspaceResetPromptResult { Waiting, Accepted, Rejected };
+bool onboardingWorkspaceReady(bool *rejected) {
+  static int attempts = 0;
+  static int stableTicks = 0;
+  if (rejected) *rejected = false;
+  void *rawRegistry = dlsym(RTLD_DEFAULT, kGlobalWidgetTagRegistrySymbol);
+  void *rawFindWidget = dlsym(RTLD_DEFAULT, kFindTaggedWidgetSymbol);
+  if (!rawRegistry || !rawFindWidget) {
+    markDone(QStringLiteral("ERROR onboarding widget registry ABI missing"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  using GlobalWidgetTagRegistry = void *(*)();
+  using FindTaggedWidget = QWidget *(*)(const void *, const std::string &);
+  const void *registry =
+      reinterpret_cast<GlobalWidgetTagRegistry>(rawRegistry)();
+  if (!registry) {
+    markDone(QStringLiteral("ERROR onboarding widget registry unavailable"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+
+  QList<QWidget *> mainDocks;
+  for (QWidget *widget : QApplication::allWidgets()) {
+    if (widget && widget->isVisible() &&
+        className(widget) == QStringLiteral("MainDock"))
+      mainDocks << widget;
+  }
+  if (mainDocks.size() > 1) {
+    markDone(QStringLiteral("ERROR onboarding MainDock ambiguous"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+
+  static constexpr std::array<const char *, 5> tags = {
+      "viewport", "sceneTree", "attributeEditor", "timeline",
+      "projectAssets"};
+  QStringList missing;
+  const auto findWidget = reinterpret_cast<FindTaggedWidget>(rawFindWidget);
+  for (const char *tag : tags) {
+    if (!findWidget(registry, std::string(tag)))
+      missing << QString::fromLatin1(tag);
+  }
+  if (mainDocks.size() != 1 || !missing.isEmpty()) {
+    stableTicks = 0;
+    if (++attempts > 120) {
+      markDone(QStringLiteral("ERROR onboarding workspace readiness main=%1 missing=%2")
+                   .arg(mainDocks.size())
+                   .arg(missing.join(QLatin1Char(','))));
+      if (rejected) *rejected = true;
+    }
+    return false;
+  }
+  if (++stableTicks < 5) return false;
+  if (stableTicks == 5)
+    appendLog(QStringLiteral("ONBOARDING_WORKSPACE_READY tags=5 stableTicks=5"));
+  return true;
+}
 
 struct WorkspaceResetOracle {
   const char *language;
@@ -23,8 +83,6 @@ struct WorkspaceResetOracle {
   const char *cancel;
 };
 
-NSTimer *gWorkspaceResetModalTimer = nil;
-
 const WorkspaceResetOracle *currentWorkspaceResetOracle() {
   static const WorkspaceResetOracle oracles[] = {
       {"zh-Hans", "重置工作区？", "本指南在默认布局下效果最佳。是否立即重置？",
@@ -33,7 +91,7 @@ const WorkspaceResetOracle *currentWorkspaceResetOracle() {
        "確定", "取消"},
       {"ja_JP", "ワークスペースをリセットしますか？",
        "このガイドはデフォルトレイアウトで最適に動作します。今すぐリセットしますか？",
-       "OK", "キャンセル"},
+       "了解", "キャンセル"},
   };
   const QString language =
       QString::fromUtf8(std::getenv("CAVALRY_I18N_LANG") ?: "");
@@ -43,150 +101,118 @@ const WorkspaceResetOracle *currentWorkspaceResetOracle() {
   return nullptr;
 }
 
-void logWorkspaceResetTopology(QWidget *root) {
-  appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_MISMATCH root=%1")
-                .arg(className(root)));
-  for (QLabel *label : root->findChildren<QLabel *>()) {
-    if (label && label->isVisibleTo(root))
-      appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_VISIBLE_LABEL text=%1")
-                    .arg(normalizedPlainText(label->text())));
-  }
-  for (QAbstractButton *button : root->findChildren<QAbstractButton *>()) {
-    if (button && button->isVisibleTo(root))
-      appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_VISIBLE_BUTTON text=%1 enabled=%2")
-                    .arg(button->text())
-                    .arg(button->isEnabled()));
-  }
-}
-
-bool isGuideChoicePopOver(QWidget *root) {
-  if (!root) return false;
-  for (QWidget *child : root->findChildren<QWidget *>()) {
-    if (child && child->isVisibleTo(root) &&
-        className(child).contains(QStringLiteral("OnboardingChoiceView")))
-      return true;
-  }
-  return false;
-}
-
-bool hasVisibleGuideChoice() {
-  for (QWidget *widget : QApplication::allWidgets()) {
-    if (widget && widget->isVisible() &&
-        className(widget).contains(QStringLiteral("OnboardingChoiceView")))
-      return true;
-  }
-  return false;
-}
-
-bool exactWorkspaceResetPrompt(QWidget *root,
-                               const WorkspaceResetOracle &oracle,
-                               QPointer<QAbstractButton> *confirmOut) {
-  if (!root || !confirmOut) return false;
-  int titleHits = 0;
-  int bodyHits = 0;
-  for (QLabel *label : root->findChildren<QLabel *>()) {
-    if (!label || !label->isVisibleTo(root)) continue;
-    const QString text = normalizedPlainText(label->text());
-    titleHits += text == QString::fromUtf8(oracle.title);
-    bodyHits += text == QString::fromUtf8(oracle.body);
-  }
-  QList<QAbstractButton *> buttons;
-  QPointer<QAbstractButton> confirm;
-  int cancelHits = 0;
-  for (QAbstractButton *button : root->findChildren<QAbstractButton *>()) {
-    if (!button || !button->isVisibleTo(root) || !button->isEnabled()) continue;
-    buttons << button;
-    if (button->text() == QString::fromUtf8(oracle.confirm)) confirm = button;
-    cancelHits += button->text() == QString::fromUtf8(oracle.cancel);
-  }
-  const bool exact = titleHits == 1 && bodyHits == 1 && buttons.size() == 2 &&
-                     confirm && cancelHits == 1;
-  if (exact) *confirmOut = confirm;
-  return exact;
-}
-
-WorkspaceResetPromptResult handleWorkspaceResetPrompt() {
-  QList<QWidget *> prompts;
-  for (QWidget *widget : QApplication::allWidgets()) {
-    if (widget && widget->isVisible() &&
-        className(widget) == QStringLiteral("PopOverView") &&
-        onboardingStep(widget) == 0)
-      prompts << widget;
-  }
-  if (prompts.isEmpty()) return WorkspaceResetPromptResult::Waiting;
-  const WorkspaceResetOracle *oracle = currentWorkspaceResetOracle();
-  if (!oracle) {
-    markDone(QStringLiteral("ERROR onboarding reset workspace prompt language"));
-    return WorkspaceResetPromptResult::Rejected;
-  }
-  QPointer<QAbstractButton> confirm;
-  int resetHits = 0;
-  bool onlyGuideChoice = true;
-  for (QWidget *root : prompts) {
-    QPointer<QAbstractButton> candidate;
-    if (exactWorkspaceResetPrompt(root, *oracle, &candidate)) {
-      resetHits += 1;
-      confirm = candidate;
-    } else {
-      onlyGuideChoice = onlyGuideChoice && isGuideChoicePopOver(root);
+QString workspaceResetButtonText(QWidget *button) {
+  if (auto *abstractButton = qobject_cast<QAbstractButton *>(button))
+    return abstractButton->text().trimmed();
+  QString text = button ? button->property("text").toString().trimmed()
+                        : QString();
+  if (!text.isEmpty()) return text;
+  QList<QLabel *> labels = button->findChildren<QLabel *>();
+  for (QLabel *label : labels) {
+    if (label && label->isVisibleTo(button) && !label->text().trimmed().isEmpty()) {
+      if (!text.isEmpty()) return QString();
+      text = label->text().trimmed();
     }
   }
-  if (resetHits == 0 && onlyGuideChoice)
-    return WorkspaceResetPromptResult::Waiting;
-  if (resetHits != 1 || !confirm) {
-    for (QWidget *root : prompts) logWorkspaceResetTopology(root);
-    markDone(QStringLiteral("ERROR onboarding reset workspace prompt topology"));
-    return WorkspaceResetPromptResult::Rejected;
+  return text;
+}
+
+void logWorkspaceResetTopology(QWidget *root) {
+  appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_MISMATCH root=%1 title=%2")
+                .arg(className(root), normalizedPlainText(root->windowTitle())));
+  for (QWidget *widget : root->findChildren<QWidget *>()) {
+    if (!widget || !widget->isVisibleTo(root)) continue;
+    QString text;
+    if (auto *button = qobject_cast<QAbstractButton *>(widget))
+      text = button->text().trimmed();
+    else if (auto *label = qobject_cast<QLabel *>(widget))
+      text = normalizedPlainText(label->text());
+    else if (className(widget) == QStringLiteral("Button"))
+      text = workspaceResetButtonText(widget);
+    appendLog(QStringLiteral("ONBOARDING_RESET_WIDGET class=%1 text=%2")
+                  .arg(className(widget), text));
   }
-  appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT accepted title=%1")
-                .arg(QString::fromUtf8(oracle->title)));
-  confirm->click();
-  return WorkspaceResetPromptResult::Accepted;
 }
 
-void disarmWorkspaceResetModalPoll() {
-  if (!gWorkspaceResetModalTimer) return;
-  [gWorkspaceResetModalTimer invalidate];
-  gWorkspaceResetModalTimer = nil;
+class WorkspaceResetEventFilter final : public QObject {
+ public:
+  using QObject::QObject;
+
+ protected:
+  bool eventFilter(QObject *watched, QEvent *event) override {
+    if (handled_ || !event || event->type() != QEvent::Paint) return false;
+    auto *painted = qobject_cast<QWidget *>(watched);
+    if (!painted) return false;
+    const WorkspaceResetOracle *oracle = currentWorkspaceResetOracle();
+    if (!oracle) return false;
+
+    QList<QWidget *> matchingRoots;
+    for (QWidget *root : QApplication::allWidgets()) {
+      if (!root || !root->isVisible() ||
+          className(root) != QStringLiteral("QMessageBox") ||
+          onboardingStep(root) != 0)
+        continue;
+      int titleHits = 0;
+      int bodyHits = 0;
+      for (QLabel *label : root->findChildren<QLabel *>()) {
+        if (!label || !label->isVisibleTo(root)) continue;
+        const QString text = normalizedPlainText(label->text());
+        titleHits += text == QString::fromUtf8(oracle->title);
+        bodyHits += text == QString::fromUtf8(oracle->body);
+      }
+      if (titleHits == 1 && bodyHits == 1) matchingRoots << root;
+    }
+    if (matchingRoots.isEmpty()) return false;
+    if (matchingRoots.size() != 1) {
+      handled_ = true;
+      markDone(QStringLiteral("ERROR onboarding reset prompt ambiguous"));
+      return false;
+    }
+
+    QWidget *root = matchingRoots.front();
+    QList<QWidget *> buttons;
+    QPointer<QWidget> confirm;
+    int cancelHits = 0;
+    for (QWidget *widget : root->findChildren<QWidget *>()) {
+      if (!widget || !widget->isVisibleTo(root) || !widget->isEnabled() ||
+          !qobject_cast<QAbstractButton *>(widget))
+        continue;
+      buttons << widget;
+      const QString text = workspaceResetButtonText(widget);
+      if (text == QString::fromUtf8(oracle->confirm)) confirm = widget;
+      cancelHits += text == QString::fromUtf8(oracle->cancel);
+    }
+    if (buttons.size() != 2 || !confirm || cancelHits != 1) {
+      if (qobject_cast<QAbstractButton *>(painted)) {
+        handled_ = true;
+        logWorkspaceResetTopology(root);
+        markDone(QStringLiteral("ERROR onboarding reset prompt controls"));
+      }
+      return false;
+    }
+
+    handled_ = true;
+    appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT accepted title=%1")
+                  .arg(QString::fromUtf8(oracle->title)));
+    if (!QMetaObject::invokeMethod(confirm, "click", Qt::QueuedConnection))
+      markDone(QStringLiteral("ERROR onboarding reset prompt click queue"));
+    return false;
+  }
+
+ private:
+  bool handled_ = false;
+};
+
+void installWorkspaceResetEventFilter() {
+  static WorkspaceResetEventFilter *filter = nullptr;
+  if (!filter && qApp) {
+    filter = new WorkspaceResetEventFilter(qApp);
+    qApp->installEventFilter(filter);
+  }
 }
 
-bool triggerFirstLaunchFromChoiceView();
-
-void armWorkspaceResetModalPoll() {
-  if (gWorkspaceResetModalTimer) return;
-  gWorkspaceResetModalTimer =
-      [NSTimer timerWithTimeInterval:0.05
-                               repeats:YES
-                               block:^(NSTimer *) {
-                                 const WorkspaceResetPromptResult result =
-                                     handleWorkspaceResetPrompt();
-                                 if (result ==
-                                     WorkspaceResetPromptResult::Rejected) {
-                                   disarmWorkspaceResetModalPoll();
-                                   return;
-                                 }
-                                 if (result ==
-                                     WorkspaceResetPromptResult::Accepted) {
-                                   disarmWorkspaceResetModalPoll();
-                                   armWorkspaceResetModalPoll();
-                                   return;
-                                 }
-                                 if (hasVisibleGuideChoice()) {
-                                   disarmWorkspaceResetModalPoll();
-                                   gTriggerAttempted =
-                                       triggerFirstLaunchFromChoiceView();
-                                   if (!gTriggerAttempted)
-                                     markDone(QStringLiteral(
-                                         "ERROR onboarding choice trigger"));
-                                 }
-                               }];
-  [[NSRunLoop mainRunLoop] addTimer:gWorkspaceResetModalTimer
-                           forMode:NSRunLoopCommonModes];
-  [[NSRunLoop mainRunLoop] addTimer:gWorkspaceResetModalTimer
-                           forMode:NSModalPanelRunLoopMode];
-}
-
-QObject *findOnboardingManager() {
+QObject *findOnboardingManager(QString *error) {
+  if (error) error->clear();
   QSet<QObject *> seen;
   QList<QObject *> objects;
   if (qApp) {
@@ -196,62 +222,92 @@ QObject *findOnboardingManager() {
   for (QWidget *widget : QApplication::allWidgets()) {
     if (!widget) continue;
     objects << widget;
+    for (QAction *action : widget->actions()) objects << action;
+    for (QAction *action : widget->findChildren<QAction *>()) objects << action;
     objects.append(widget->findChildren<QObject *>());
   }
-  for (QObject *object : objects) {
-    if (!object || seen.contains(object)) continue;
-    seen.insert(object);
-    if (!className(object).contains(QStringLiteral("OnboardingManager")))
-      continue;
-    appendLog(
-        QStringLiteral("ONBOARDING_MANAGER class=%1 parent=%2 scanned=%3")
-            .arg(className(object), className(object->parent()))
-            .arg(seen.size()));
-    return object;
-  }
-  return nullptr;
-}
 
-bool triggerFirstLaunchGuide() {
-  QObject *manager = findOnboardingManager();
-  const char *symbol =
-      "_ZN10onboarding17OnboardingManager9showGuideERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
-  void *raw = manager ? dlsym(RTLD_DEFAULT, symbol) : nullptr;
-  if (!manager || !raw) return false;
-  armWorkspaceResetModalPoll();
-  using ShowGuide = void (*)(void *, const std::string &);
-  reinterpret_cast<ShowGuide>(raw)(
-      manager, std::string("firstLaunch"));
-  appendLog(QStringLiteral("ONBOARDING_TRIGGER manager id=firstLaunch"));
-  return true;
-}
-
-bool triggerFirstLaunchFromChoiceView() {
-  for (QWidget *widget : QApplication::allWidgets()) {
-    if (!widget || !widget->isVisible() ||
-        !className(widget).contains(QStringLiteral("OnboardingChoiceView"))) {
-      continue;
+  QList<QObject *> managers;
+  QList<QObject *> guiObjects;
+  for (QObject *root : objects) {
+    for (QObject *object = root; object; object = object->parent()) {
+      if (seen.contains(object)) continue;
+      seen.insert(object);
+      const QString runtimeClass = className(object);
+      if (runtimeClass == QString::fromLatin1(kOnboardingManagerClass))
+        managers << object;
+      else if (runtimeClass == QString::fromLatin1(kGuiClass))
+        guiObjects << object;
     }
-    const char *symbol =
-        "_ZN10onboarding20OnboardingChoiceView13guideSelectedERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
-    void *raw = dlsym(RTLD_DEFAULT, symbol);
-    if (!raw) return false;
-    armWorkspaceResetModalPoll();
-    using GuideSelected = void (*)(void *, const std::string &);
-    const QString choiceClass = className(widget);
-    reinterpret_cast<GuideSelected>(raw)(
-        widget, std::string("firstLaunch"));
-    appendLog(
-        QStringLiteral(
-            "ONBOARDING_TRIGGER choice-view class=%1 id=firstLaunch")
-            .arg(choiceClass));
-    return true;
   }
-  return false;
+
+  if (managers.size() > 1) {
+    if (error)
+      *error = QStringLiteral("OnboardingManager identity ambiguous count=%1")
+                   .arg(managers.size());
+    return nullptr;
+  }
+  if (managers.size() == 1) {
+    appendLog(QStringLiteral("ONBOARDING_MANAGER source=object-graph class=%1")
+                  .arg(className(managers.front())));
+    return managers.front();
+  }
+  if (guiObjects.isEmpty()) return nullptr;
+  if (guiObjects.size() != 1) {
+    if (error)
+      *error = QStringLiteral("Gui identity ambiguous count=%1")
+                   .arg(guiObjects.size());
+    return nullptr;
+  }
+
+  void *rawGetter = dlsym(RTLD_DEFAULT, kOnboardingManagerGetterSymbol);
+  if (!rawGetter) {
+    if (error) *error = QStringLiteral("Gui::onboardingManager export missing");
+    return nullptr;
+  }
+  using OnboardingManagerGetter = void *(*)(void *);
+  void *rawManager = reinterpret_cast<OnboardingManagerGetter>(rawGetter)(
+      guiObjects.front());
+  if (!rawManager) {
+    if (error) *error = QStringLiteral("Gui::onboardingManager returned null");
+    return nullptr;
+  }
+  auto *manager = reinterpret_cast<QObject *>(rawManager);
+  if (className(manager) != QString::fromLatin1(kOnboardingManagerClass)) {
+    if (error)
+      *error = QStringLiteral("Gui::onboardingManager class mismatch actual=%1")
+                   .arg(className(manager));
+    return nullptr;
+  }
+  appendLog(QStringLiteral("ONBOARDING_MANAGER source=gui-getter class=%1")
+                .arg(className(manager)));
+  return manager;
 }
 
-bool triggerGuideInQtActions() {
+bool isGuideActionText(QString title) {
+  title.remove(QLatin1Char('&'));
+  title = title.trimmed();
+  return title == QStringLiteral("Getting Started Guides") ||
+         title == QStringLiteral("入门指南") ||
+         title == QStringLiteral("入門指南") ||
+         title == QStringLiteral("スタートガイド");
+}
+
+QAction *findShowGuidesAction(QString *error) {
   QSet<QAction *> seen;
+  QList<QAction *> exact;
+  QList<QAction *> translated;
+  if (qApp) {
+    for (QAction *action : qApp->findChildren<QAction *>()) {
+      if (!action || seen.contains(action)) continue;
+      seen.insert(action);
+      if (action->objectName() ==
+          QString::fromLatin1(kShowGuidesActionObjectName))
+        exact << action;
+      else if (isGuideActionText(action->text()))
+        translated << action;
+    }
+  }
   for (QWidget *widget : QApplication::allWidgets()) {
     if (!widget) continue;
     QList<QAction *> actions = widget->actions();
@@ -259,20 +315,171 @@ bool triggerGuideInQtActions() {
     for (QAction *action : actions) {
       if (!action || seen.contains(action)) continue;
       seen.insert(action);
-      if (!action->isEnabled() || !isGuideActionText(action->text()))
-        continue;
-      const QString text = action->text();
-      const QPointer<QAction> guarded(action);
-      armWorkspaceResetModalPoll();
-      QTimer::singleShot(0, qApp, [guarded] {
-        if (guarded) guarded->trigger();
-      });
-      appendLog(
-          QStringLiteral("ONBOARDING_TRIGGER qt-action-queued text=%1 parent=%2")
-              .arg(text, className(action->parent())));
-      return true;
+      if (action->objectName() ==
+          QString::fromLatin1(kShowGuidesActionObjectName))
+        exact << action;
+      else if (isGuideActionText(action->text()))
+        translated << action;
     }
   }
+  const QList<QAction *> &candidates = exact.isEmpty() ? translated : exact;
+  if (candidates.size() > 1 && error)
+    *error = QStringLiteral("Getting Started Guides action ambiguous count=%1")
+                 .arg(candidates.size());
+  return candidates.size() == 1 ? candidates.front() : nullptr;
+}
+
+QWidget *findOnboardingChoice(QString *error) {
+  QList<QWidget *> choices;
+  for (QWidget *widget : QApplication::allWidgets()) {
+    if (widget && widget->isVisible() &&
+        className(widget) == QString::fromLatin1(kOnboardingChoiceClass))
+      choices << widget;
+  }
+  if (choices.size() > 1 && error)
+    *error = QStringLiteral("OnboardingChoiceView ambiguous count=%1")
+                 .arg(choices.size());
+  return choices.size() == 1 ? choices.front() : nullptr;
+}
+
+QObject *onboardingManagerFromChoice(QWidget *choice, QString *error) {
+  if (!choice ||
+      className(choice) != QString::fromLatin1(kOnboardingChoiceClass)) {
+    if (error) *error = QStringLiteral("OnboardingChoiceView class mismatch");
+    return nullptr;
+  }
+  QObjectList receivers = QObjectPrivate::get(choice)->receiverList(
+      SIGNAL(guideSelected(std::string)));
+  if (receivers.isEmpty())
+    receivers = QObjectPrivate::get(choice)->receiverList(
+        "guideSelected(std::string)");
+  QSet<QObject *> managers;
+  for (QObject *receiver : receivers) {
+    if (className(receiver) == QString::fromLatin1(kOnboardingManagerClass))
+      managers.insert(receiver);
+  }
+  if (managers.size() != 1) {
+    if (error)
+      *error = QStringLiteral("guideSelected manager receiver count=%1")
+                   .arg(managers.size());
+    return nullptr;
+  }
+  QObject *manager = *managers.constBegin();
+  appendLog(QStringLiteral("ONBOARDING_MANAGER source=choice-receiver class=%1")
+                .arg(className(manager)));
+  return manager;
+}
+
+bool triggerFirstLaunchFromChoice(QWidget *choice, QObject *manager,
+                                  bool *rejected) {
+  if (!choice || !manager) return false;
+  QMetaMethod guideSelected;
+  QByteArray parameterType;
+  const QMetaObject *metaObject = choice->metaObject();
+  for (int index = 0; index < metaObject->methodCount(); ++index) {
+    const QMetaMethod method = metaObject->method(index);
+    const QList<QByteArray> parameters = method.parameterTypes();
+    if (method.name() == QByteArrayLiteral("guideSelected") &&
+        parameters.size() == 1 &&
+        parameters.front() == QByteArrayLiteral("std::string")) {
+      guideSelected = method;
+      parameterType = parameters.front();
+      break;
+    }
+  }
+  if (!guideSelected.isValid()) {
+    markDone(QStringLiteral("ERROR onboarding guideSelected(std::string) ABI"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  installWorkspaceResetEventFilter();
+  const QString receiverClass = className(manager);
+  const std::string guideId("firstLaunch");
+  if (!guideSelected.invoke(choice, Qt::DirectConnection,
+                            QGenericArgument(parameterType.constData(),
+                                             &guideId))) {
+    markDone(QStringLiteral("ERROR onboarding guideSelected invocation"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  appendLog(QStringLiteral(
+      "ONBOARDING_TRIGGER choice id=firstLaunch receiver=%1")
+                .arg(receiverClass));
+  return true;
+}
+
+bool showFirstLaunchGuide(QObject *manager, bool *rejected) {
+  if (!manager ||
+      className(manager) != QString::fromLatin1(kOnboardingManagerClass)) {
+    markDone(QStringLiteral("ERROR onboarding manager class mismatch"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  installWorkspaceResetEventFilter();
+  void *rawShowGuide = dlsym(RTLD_DEFAULT, kShowGuideSymbol);
+  if (!rawShowGuide) {
+    markDone(QStringLiteral("ERROR onboarding showGuide export missing"));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  using ShowGuide = void (*)(void *, const std::string &);
+  reinterpret_cast<ShowGuide>(rawShowGuide)(manager,
+                                            std::string("firstLaunch"));
+  appendLog(QStringLiteral("ONBOARDING_TRIGGER manager id=firstLaunch"));
+  return true;
+}
+
+bool triggerFirstLaunchGuide(bool *rejected) {
+  if (rejected) *rejected = false;
+  QString error;
+  QObject *manager = findOnboardingManager(&error);
+  if (!error.isEmpty()) {
+    appendLog(QStringLiteral("ONBOARDING_MANAGER_ERROR %1").arg(error));
+    markDone(QStringLiteral("ERROR onboarding manager resolution: %1")
+                 .arg(error));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  if (manager) return showFirstLaunchGuide(manager, rejected);
+
+  QWidget *choice = findOnboardingChoice(&error);
+  if (!error.isEmpty()) {
+    markDone(QStringLiteral("ERROR onboarding choice resolution: %1")
+                 .arg(error));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  if (choice) {
+    manager = onboardingManagerFromChoice(choice, &error);
+    if (!manager) {
+      markDone(QStringLiteral("ERROR onboarding choice manager: %1")
+                   .arg(error));
+      if (rejected) *rejected = true;
+      return false;
+    }
+    return triggerFirstLaunchFromChoice(choice, manager, rejected);
+  }
+
+  if (gGuideChooserOpened) return false;
+  QAction *action = findShowGuidesAction(&error);
+  if (!error.isEmpty()) {
+    markDone(QStringLiteral("ERROR onboarding action resolution: %1")
+                 .arg(error));
+    if (rejected) *rejected = true;
+    return false;
+  }
+  if (!action) return false;
+  const QString identity = action->objectName().isEmpty()
+                               ? action->text()
+                               : action->objectName();
+  const bool wasEnabled = action->isEnabled();
+  QPointer<QAction> guarded(action);
+  if (!wasEnabled) action->setEnabled(true);
+  action->trigger();
+  if (guarded && !wasEnabled) guarded->setEnabled(false);
+  gGuideChooserOpened = true;
+  appendLog(QStringLiteral("ONBOARDING_TRIGGER chooser action=%1")
+                .arg(identity));
   return false;
 }
 
@@ -293,29 +500,4 @@ void logOnboardingContentTopology(QWidget *root, int step) {
                        normalizedPlainText(browser->toPlainText()),
                        normalizedPlainText(browser->toHtml())));
   }
-}
-
-bool triggerGuideInNativeMenu(NSMenu *menu) {
-  if (menu == nil) return false;
-  for (NSMenuItem *item in [menu itemArray]) {
-    NSString *nativeTitle = [item title] ?: @"";
-    const QString title =
-        QString::fromUtf8([nativeTitle UTF8String]);
-    if ([item isEnabled] && [item action] != nil &&
-        isGuideActionText(title)) {
-      armWorkspaceResetModalPoll();
-      const BOOL sent =
-          [NSApp sendAction:[item action] to:[item target] from:item];
-      appendLog(
-          QStringLiteral("ONBOARDING_TRIGGER native-action text=%1 sent=%2")
-              .arg(title)
-              .arg(sent));
-      return sent;
-    }
-    if ([item hasSubmenu] &&
-        triggerGuideInNativeMenu([item submenu])) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/tools/macos-acceptance/drivers/macos_supplemental_onboarding_trigger.inc
+++ b/tools/macos-acceptance/drivers/macos_supplemental_onboarding_trigger.inc
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: Qt 完整对象图与事件循环、Qt/native 菜单、OnboardingChoiceView 与 Cavalry 2.7.2 的 onboarding C++ ABI。
- * [OUTPUT]: 通过 manager、真实入门指南菜单或 choice signal 语义触发 firstLaunch guide，并在内容契约失败时输出可证伪拓扑。
- * [POS]: supplemental onboarding 的入口解析器；只负责非重入地打开真实产品 guide 和记录失败事实，不构造验收 UI。
+ * [INPUT]: Qt 完整对象图、AppKit modal run-loop mode、Qt/native 菜单、可选 reset PopOverView、OnboardingChoiceView 与 Cavalry 2.7.2 的 onboarding C++ ABI。
+ * [OUTPUT]: 通过 manager、真实入门指南菜单或 choice signal 语义触发 firstLaunch guide，并只在精确匹配本地化 reset-workspace 对话框时确认默认布局。
+ * [POS]: supplemental onboarding 的入口解析器；用 mode-aware timer 穿过同步产品弹窗后打开真实 guide，并对任何未知 modal 拓扑失败关闭，不构造验收 UI。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 bool isGuideActionText(QString title) {
@@ -11,6 +11,179 @@ bool isGuideActionText(QString title) {
          title == QStringLiteral("入门指南") ||
          title == QStringLiteral("入門指南") ||
          title == QStringLiteral("スタートガイド");
+}
+
+enum class WorkspaceResetPromptResult { Waiting, Accepted, Rejected };
+
+struct WorkspaceResetOracle {
+  const char *language;
+  const char *title;
+  const char *body;
+  const char *confirm;
+  const char *cancel;
+};
+
+NSTimer *gWorkspaceResetModalTimer = nil;
+
+const WorkspaceResetOracle *currentWorkspaceResetOracle() {
+  static const WorkspaceResetOracle oracles[] = {
+      {"zh-Hans", "重置工作区？", "本指南在默认布局下效果最佳。是否立即重置？",
+       "确定", "取消"},
+      {"zh-Hant", "重設工作區？", "本指南在預設版面配置下效果最佳。是否立即重設？",
+       "確定", "取消"},
+      {"ja_JP", "ワークスペースをリセットしますか？",
+       "このガイドはデフォルトレイアウトで最適に動作します。今すぐリセットしますか？",
+       "OK", "キャンセル"},
+  };
+  const QString language =
+      QString::fromUtf8(std::getenv("CAVALRY_I18N_LANG") ?: "");
+  for (const WorkspaceResetOracle &oracle : oracles) {
+    if (language == QString::fromLatin1(oracle.language)) return &oracle;
+  }
+  return nullptr;
+}
+
+void logWorkspaceResetTopology(QWidget *root) {
+  appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_MISMATCH root=%1")
+                .arg(className(root)));
+  for (QLabel *label : root->findChildren<QLabel *>()) {
+    if (label && label->isVisibleTo(root))
+      appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_VISIBLE_LABEL text=%1")
+                    .arg(normalizedPlainText(label->text())));
+  }
+  for (QAbstractButton *button : root->findChildren<QAbstractButton *>()) {
+    if (button && button->isVisibleTo(root))
+      appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT_VISIBLE_BUTTON text=%1 enabled=%2")
+                    .arg(button->text())
+                    .arg(button->isEnabled()));
+  }
+}
+
+bool isGuideChoicePopOver(QWidget *root) {
+  if (!root) return false;
+  for (QWidget *child : root->findChildren<QWidget *>()) {
+    if (child && child->isVisibleTo(root) &&
+        className(child).contains(QStringLiteral("OnboardingChoiceView")))
+      return true;
+  }
+  return false;
+}
+
+bool hasVisibleGuideChoice() {
+  for (QWidget *widget : QApplication::allWidgets()) {
+    if (widget && widget->isVisible() &&
+        className(widget).contains(QStringLiteral("OnboardingChoiceView")))
+      return true;
+  }
+  return false;
+}
+
+bool exactWorkspaceResetPrompt(QWidget *root,
+                               const WorkspaceResetOracle &oracle,
+                               QPointer<QAbstractButton> *confirmOut) {
+  if (!root || !confirmOut) return false;
+  int titleHits = 0;
+  int bodyHits = 0;
+  for (QLabel *label : root->findChildren<QLabel *>()) {
+    if (!label || !label->isVisibleTo(root)) continue;
+    const QString text = normalizedPlainText(label->text());
+    titleHits += text == QString::fromUtf8(oracle.title);
+    bodyHits += text == QString::fromUtf8(oracle.body);
+  }
+  QList<QAbstractButton *> buttons;
+  QPointer<QAbstractButton> confirm;
+  int cancelHits = 0;
+  for (QAbstractButton *button : root->findChildren<QAbstractButton *>()) {
+    if (!button || !button->isVisibleTo(root) || !button->isEnabled()) continue;
+    buttons << button;
+    if (button->text() == QString::fromUtf8(oracle.confirm)) confirm = button;
+    cancelHits += button->text() == QString::fromUtf8(oracle.cancel);
+  }
+  const bool exact = titleHits == 1 && bodyHits == 1 && buttons.size() == 2 &&
+                     confirm && cancelHits == 1;
+  if (exact) *confirmOut = confirm;
+  return exact;
+}
+
+WorkspaceResetPromptResult handleWorkspaceResetPrompt() {
+  QList<QWidget *> prompts;
+  for (QWidget *widget : QApplication::allWidgets()) {
+    if (widget && widget->isVisible() &&
+        className(widget) == QStringLiteral("PopOverView") &&
+        onboardingStep(widget) == 0)
+      prompts << widget;
+  }
+  if (prompts.isEmpty()) return WorkspaceResetPromptResult::Waiting;
+  const WorkspaceResetOracle *oracle = currentWorkspaceResetOracle();
+  if (!oracle) {
+    markDone(QStringLiteral("ERROR onboarding reset workspace prompt language"));
+    return WorkspaceResetPromptResult::Rejected;
+  }
+  QPointer<QAbstractButton> confirm;
+  int resetHits = 0;
+  bool onlyGuideChoice = true;
+  for (QWidget *root : prompts) {
+    QPointer<QAbstractButton> candidate;
+    if (exactWorkspaceResetPrompt(root, *oracle, &candidate)) {
+      resetHits += 1;
+      confirm = candidate;
+    } else {
+      onlyGuideChoice = onlyGuideChoice && isGuideChoicePopOver(root);
+    }
+  }
+  if (resetHits == 0 && onlyGuideChoice)
+    return WorkspaceResetPromptResult::Waiting;
+  if (resetHits != 1 || !confirm) {
+    for (QWidget *root : prompts) logWorkspaceResetTopology(root);
+    markDone(QStringLiteral("ERROR onboarding reset workspace prompt topology"));
+    return WorkspaceResetPromptResult::Rejected;
+  }
+  appendLog(QStringLiteral("ONBOARDING_RESET_PROMPT accepted title=%1")
+                .arg(QString::fromUtf8(oracle->title)));
+  confirm->click();
+  return WorkspaceResetPromptResult::Accepted;
+}
+
+void disarmWorkspaceResetModalPoll() {
+  if (!gWorkspaceResetModalTimer) return;
+  [gWorkspaceResetModalTimer invalidate];
+  gWorkspaceResetModalTimer = nil;
+}
+
+bool triggerFirstLaunchFromChoiceView();
+
+void armWorkspaceResetModalPoll() {
+  if (gWorkspaceResetModalTimer) return;
+  gWorkspaceResetModalTimer =
+      [NSTimer timerWithTimeInterval:0.05
+                               repeats:YES
+                               block:^(NSTimer *) {
+                                 const WorkspaceResetPromptResult result =
+                                     handleWorkspaceResetPrompt();
+                                 if (result ==
+                                     WorkspaceResetPromptResult::Rejected) {
+                                   disarmWorkspaceResetModalPoll();
+                                   return;
+                                 }
+                                 if (result ==
+                                     WorkspaceResetPromptResult::Accepted) {
+                                   disarmWorkspaceResetModalPoll();
+                                   armWorkspaceResetModalPoll();
+                                   return;
+                                 }
+                                 if (hasVisibleGuideChoice()) {
+                                   disarmWorkspaceResetModalPoll();
+                                   gTriggerAttempted =
+                                       triggerFirstLaunchFromChoiceView();
+                                   if (!gTriggerAttempted)
+                                     markDone(QStringLiteral(
+                                         "ERROR onboarding choice trigger"));
+                                 }
+                               }];
+  [[NSRunLoop mainRunLoop] addTimer:gWorkspaceResetModalTimer
+                           forMode:NSRunLoopCommonModes];
+  [[NSRunLoop mainRunLoop] addTimer:gWorkspaceResetModalTimer
+                           forMode:NSModalPanelRunLoopMode];
 }
 
 QObject *findOnboardingManager() {
@@ -45,6 +218,7 @@ bool triggerFirstLaunchGuide() {
       "_ZN10onboarding17OnboardingManager9showGuideERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
   void *raw = manager ? dlsym(RTLD_DEFAULT, symbol) : nullptr;
   if (!manager || !raw) return false;
+  armWorkspaceResetModalPoll();
   using ShowGuide = void (*)(void *, const std::string &);
   reinterpret_cast<ShowGuide>(raw)(
       manager, std::string("firstLaunch"));
@@ -62,6 +236,7 @@ bool triggerFirstLaunchFromChoiceView() {
         "_ZN10onboarding20OnboardingChoiceView13guideSelectedERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE";
     void *raw = dlsym(RTLD_DEFAULT, symbol);
     if (!raw) return false;
+    armWorkspaceResetModalPoll();
     using GuideSelected = void (*)(void *, const std::string &);
     const QString choiceClass = className(widget);
     reinterpret_cast<GuideSelected>(raw)(
@@ -88,6 +263,7 @@ bool triggerGuideInQtActions() {
         continue;
       const QString text = action->text();
       const QPointer<QAction> guarded(action);
+      armWorkspaceResetModalPoll();
       QTimer::singleShot(0, qApp, [guarded] {
         if (guarded) guarded->trigger();
       });
@@ -127,6 +303,7 @@ bool triggerGuideInNativeMenu(NSMenu *menu) {
         QString::fromUtf8([nativeTitle UTF8String]);
     if ([item isEnabled] && [item action] != nil &&
         isGuideActionText(title)) {
+      armWorkspaceResetModalPoll();
       const BOOL sent =
           [NSApp sendAction:[item action] to:[item target] from:item];
       appendLog(


### PR DESCRIPTION
## Summary

- drive the onboarding acceptance state machine exclusively from Qt timers so nested Cavalry modal loops cannot starve progress
- resolve the exact live `onboarding::OnboardingManager` through the real `guideSelected(std::string)` receiver graph and drive the localized workspace-reset prompt through its real button
- wait for a unique visible `MainDock` and the five required widget tags to remain stable for five Qt ticks before triggering onboarding
- isolate each live run's Foundation preferences with `CFFIXED_USER_HOME` instead of relying on `HOME`
- compile the supplemental driver against the pinned Qt 6.6.3 CorePrivate headers required by `qobject_p.h`
- lock these boundaries in acceptance contracts and synchronize the L2/L3 GEB maps

## Root cause

The first fix addressed a real symptom: GCD-main-queue polling stopped while Cavalry owned a nested Qt modal loop. The later crash evidence exposed a deeper pair of faults:

1. onboarding could be triggered before Cavalry had finished registering its workspace widgets; and
2. macOS Foundation ignored the harness-only `HOME` override, so supposedly disposable runs could still write the real `~/Library/Preferences/Cavalry` profile.

The final implementation fails closed until Cavalry's exact workspace registry is stable and gives every run an actual Foundation home.

## Verification

### Static and compile gates

- `npm run test:contracts` — **211/211 passed**
- `npm run test:acceptance:macos:contracts` — **13/13 passed**
- `npm run test:acceptance:macos:compile -- --qt-prefix "$PWD/qt_sdk/6.6.3/macos" --out <external-empty-dir>` — both acceptance drivers compiled and signed
- `git diff --check` — passed
- all touched business files remain at or below the repository's 800-line limit
- sealed source identity recheck — **42/42 matched**, 0 mismatches

### Fresh disposable-clone live matrix

Session UUID: `80411bf1-ef18-4d81-b6af-7129ebf2d7db`

- machine phase: **21 runs / 48 points / 54 unique screenshots**
- manual visual review: all 48 points accepted across Simplified Chinese, Traditional Chinese, and Japanese
- final status: **PASS-48-OF-48**
- machine record SHA-256: `88c600bd622ac612aa74516941471b41061e616789d3e4a3b190970688157fef`
- manual review SHA-256: `13471c76a1fbfdd8bfd1de2865a2ec0a829e95f6c5ec92c07af8f124c261eb75`
- final sealed record SHA-256: `b26dc5d6c4717875a45741c6fb9196358186a66f3c3a20164ad46294009675af`

All three onboarding runs logged the five-tag readiness gate, exact localized Guide action, unique manager receiver, and five acknowledged onboarding captures. All 21 runs wrote their workspace preferences under their disposable session homes. The canonical `/Applications/Cavalry.app` process remained running and its real preference-file mtime was unchanged by the final matrix.

## Scope

- no Developer ID signing or notarization work
- no Windows product implementation; the unrelated Windows CMake 4.2 failure remains tracked separately in #22
- no generated live evidence or Cavalry bundle is committed

Closes #23
