### PR TITLE
fix(windows): restore exact English snapshot bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ docs/ - 架构计划、翻译规范、工作流协议与历史证据链 (Markdow
 injector/ - macOS DYLD 注入器、Cavalry 2.7.2 TransformTool Mach-O/Skia ABI 防火墙与 Windows Qt generic translator/QPA delegate；共享 policy 区分 8 条跨平台 exact-only 表面和双平台 owner-scoped 邻接 key，Windows 另构建不发布的 acceptance-only generic plugin，以 Qt test profile 隔离登录/工作区并驱动 Onboarding/Tag/Assets 真机证据，各平台 Runner 现场生成不入库的原生库 (C++, Objective-C++)
 languages/ - 运行时 JSON 语言包，保存 English 基线与三语同构翻译资产 (JSON)
 renderer/ - Tauri 前端 UI，提供多语言补丁的管理界面 (HTML, JS)
-src-tauri/ - Tauri 后端；分离 renderer 契约、安装真相、受控系统命令与平台运行时，Windows 以 durable manifest/backup、含 generic 的原子 English 清理、same-EXE 单次 UAC 与可选保留翻译的 NSIS 生命周期统一控制面和数据面 (Rust, NSIS)
+src-tauri/ - Tauri 后端；分离 renderer 契约、安装真相、受控系统命令与平台运行时，Windows 以 immutable snapshot 原字节恢复、durable manifest/backup、含 generic 的原子 English 清理、same-EXE 单次 UAC 与可选保留翻译的 NSIS 生命周期统一控制面和数据面 (Rust, NSIS)
 tools/ - 自动化工具链，涵盖翻译提取、校验、SDK 解析、Windows NSIS 安装态、exact PID/HWND/受限 cleanup 与 producer-side PNG 证据，以及 tracked macOS Objective-C++/CGWindow 21-run/48-point 定向验收器；原生库和 live session 现场生成而不入库 (Node.js, PowerShell, Bash, Objective-C++, Swift)
 output/ - 派生审计产物，保存截图、JSON surface 抓取与翻译草稿 (JSON, PNG)
 </directory>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,6 +172,8 @@ pub(crate) use crate::mac_runtime::injector_source_candidates;
 pub(crate) use crate::operation_lock::acquire_bundle_file_lock;
 #[cfg(test)]
 pub(crate) use crate::operation_lock::{try_begin_bundle_operation, BUSY_ERROR};
+#[cfg(all(test, target_os = "windows"))]
+pub(crate) use apply::build_windows_language_pairs;
 #[cfg(test)]
 pub(crate) use apply::marker_guarded_transaction_pairs;
 #[cfg(test)]

--- a/src-tauri/src/commands/CLAUDE.md
+++ b/src-tauri/src/commands/CLAUDE.md
@@ -2,7 +2,7 @@
 > L2 | 父级: ../CLAUDE.md
 
 成员清单
-apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 的三种翻译保持 canonical overlay，English 则复制 immutable snapshot 原字节并经过同一 UAC 来源证明；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
+apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 的生产/测试共用 pair 构造让三种翻译保持 canonical overlay、English 复制 immutable snapshot 原字节并经过同一 UAC 来源证明；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
 context.rs: Tauri 应用路径与资源候选解析；复用 root 级 runtime_paths，把 repo、state、Resources 以及 `_up_` 打包布局统一为 command 可消费的路径上下文，并只发布固定四语 manifest。
 contract.rs: renderer 兼容 DTO 与六命令常量；集中 camelCase JSON 序列化、稳定 errorCode/可组合 warningCodes、Action/Status 的 typed `reconciliationRequired` residue 投影与 UAC `permissionRequired` 投影及内部 warning prose→code 收敛，facade 返回前清空原文，禁止把底层临时路径泄漏到 UI。
 restart.rs: 重启 command 编排；同步持久 state 后用安装真相只读投影 stale Windows marker，再委托 platform_runtime；`apply_language` 在同一 operation guard 内复用它，避免 renderer 竞态。

--- a/src-tauri/src/commands/CLAUDE.md
+++ b/src-tauri/src/commands/CLAUDE.md
@@ -2,7 +2,7 @@
 > L2 | 父级: ../CLAUDE.md
 
 成员清单
-apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 保持既有 canonical overlay/UAC 边界；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
+apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 的三种翻译保持 canonical overlay，English 则复制 immutable snapshot 原字节并经过同一 UAC 来源证明；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
 context.rs: Tauri 应用路径与资源候选解析；复用 root 级 runtime_paths，把 repo、state、Resources 以及 `_up_` 打包布局统一为 command 可消费的路径上下文，并只发布固定四语 manifest。
 contract.rs: renderer 兼容 DTO 与六命令常量；集中 camelCase JSON 序列化、稳定 errorCode/可组合 warningCodes、Action/Status 的 typed `reconciliationRequired` residue 投影与 UAC `permissionRequired` 投影及内部 warning prose→code 收敛，facade 返回前清空原文，禁止把底层临时路径泄漏到 UI。
 restart.rs: 重启 command 编排；同步持久 state 后用安装真相只读投影 stale Windows marker，再委托 platform_runtime；`apply_language` 在同一 operation guard 内复用它，避免 renderer 竞态。

--- a/src-tauri/src/commands/CLAUDE.md
+++ b/src-tauri/src/commands/CLAUDE.md
@@ -2,7 +2,7 @@
 > L2 | 父级: ../CLAUDE.md
 
 成员清单
-apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 的生产/测试共用 pair 构造让三种翻译保持 canonical overlay、English 复制 immutable snapshot 原字节并经过同一 UAC 来源证明；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
+apply.rs: 语言写入事务编排；English 快速返回仅接受无 pending journal 的精确 Clean disposition，stale marker 或未完成 Windows transaction 必须继续 pending→runtime→final 事务；Windows 的生产/测试共用 pair 构造让三种翻译保持 canonical overlay、English 复制 immutable snapshot 原字节，并把 durable manifest entry SHA 连续传入 UAC parent staging；macOS 把首次 wrapper→Info launch gate、所有 changed/filtered JSON 的 mutation/observe-only preimage、runtime、Keychain、codesign、quarantine、commit-gated marker/vendor Info/removals 与 durable state 纳入同一 authenticated transaction，官方还原先发布 vendor Info 再删除惰性 owned runtime，任一 postcondition/fsync 失败回滚完整自有 preimage。
 context.rs: Tauri 应用路径与资源候选解析；复用 root 级 runtime_paths，把 repo、state、Resources 以及 `_up_` 打包布局统一为 command 可消费的路径上下文，并只发布固定四语 manifest。
 contract.rs: renderer 兼容 DTO 与六命令常量；集中 camelCase JSON 序列化、稳定 errorCode/可组合 warningCodes、Action/Status 的 typed `reconciliationRequired` residue 投影与 UAC `permissionRequired` 投影及内部 warning prose→code 收敛，facade 返回前清空原文，禁止把底层临时路径泄漏到 UI。
 restart.rs: 重启 command 编排；同步持久 state 后用安装真相只读投影 stale Windows marker，再委托 platform_runtime；`apply_language` 在同一 operation guard 内复用它，避免 renderer 竞态。

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 snapshot/status、English 原字节快照与 keyed JSON overlay、Program Files typed parent transaction、platform_runtime direct preflight、privilege copy completion 与 Unix PermissionsExt 模式比较。
- * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、Windows English 原字节恢复与三语 canonical pretty overlay/单次 UAC/typed cleanup warning、全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
+ * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、生产与测试共用的 Windows English 原字节/三语 canonical overlay pair 构造、单次 UAC/typed cleanup warning、全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
  * [POS]: commands 的语言写入编排；Windows 让 English 恢复保留已验证快照原字节、翻译 payload 保持规范化，macOS 把 files_match 未改资产仍绑定到同一认证 generation，并在 state/transaction 提交前完成 runtime、签名与 quarantine，任一失败均回滚精确 bundle/state preimage。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -128,6 +128,21 @@ fn unique_staging_root() -> PathBuf {
         Utc::now().timestamp_millis(),
         next_staging_nonce()
     ))
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn build_windows_language_pairs(
+    effective_lang: &str,
+    source_dir: &Path,
+    english_snapshot_dir: &Path,
+    app_path: &Path,
+    overlay_dir: &Path,
+) -> Result<Vec<patch::CopyPair>, String> {
+    if effective_lang == "en" {
+        patch::build_copy_pairs_checked(source_dir, app_path)
+    } else {
+        patch::build_overlay_pairs(source_dir, english_snapshot_dir, app_path, overlay_dir)
+    }
 }
 
 fn files_match(source: &Path, destination: &Path) -> bool {
@@ -444,16 +459,13 @@ pub fn apply_language_inner<R: CommandRunner>(
         }
     };
     #[cfg(target_os = "windows")]
-    let pairs = if effective_lang == "en" {
-        patch::build_copy_pairs_checked(&source_dir, &app_path)?
-    } else {
-        patch::build_overlay_pairs(
-            &source_dir,
-            &english_snapshot_dir,
-            &app_path,
-            &staging_root.join("overlay"),
-        )?
-    };
+    let pairs = build_windows_language_pairs(
+        effective_lang,
+        &source_dir,
+        &english_snapshot_dir,
+        &app_path,
+        &staging_root.join("overlay"),
+    )?;
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let pairs = if effective_lang == "en" {
         patch::build_copy_pairs_checked(&source_dir, &app_path)?

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 依赖 snapshot/status、English-baseline JSON overlay、Program Files typed parent transaction、platform_runtime direct preflight、privilege copy completion 与 Unix PermissionsExt 模式比较。
- * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、Windows 四语言 canonical pretty overlay/单次 UAC/typed cleanup warning 与全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
- * [POS]: commands 的语言写入编排；Windows 为 source provenance 统一规范化 English/翻译 payload，macOS 把 files_match 未改资产仍绑定到同一认证 generation，并在 state/transaction 提交前完成 runtime、签名与 quarantine，任一失败均回滚精确 bundle/state preimage。
+ * [INPUT]: 依赖 snapshot/status、English 原字节快照与 keyed JSON overlay、Program Files typed parent transaction、platform_runtime direct preflight、privilege copy completion 与 Unix PermissionsExt 模式比较。
+ * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、Windows English 原字节恢复与三语 canonical pretty overlay/单次 UAC/typed cleanup warning、全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
+ * [POS]: commands 的语言写入编排；Windows 让 English 恢复保留已验证快照原字节、翻译 payload 保持规范化，macOS 把 files_match 未改资产仍绑定到同一认证 generation，并在 state/transaction 提交前完成 runtime、签名与 quarantine，任一失败均回滚精确 bundle/state preimage。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 use chrono::Utc;
@@ -444,12 +444,16 @@ pub fn apply_language_inner<R: CommandRunner>(
         }
     };
     #[cfg(target_os = "windows")]
-    let pairs = patch::build_overlay_pairs(
-        &source_dir,
-        &english_snapshot_dir,
-        &app_path,
-        &staging_root.join("overlay"),
-    )?;
+    let pairs = if effective_lang == "en" {
+        patch::build_copy_pairs_checked(&source_dir, &app_path)?
+    } else {
+        patch::build_overlay_pairs(
+            &source_dir,
+            &english_snapshot_dir,
+            &app_path,
+            &staging_root.join("overlay"),
+        )?
+    };
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let pairs = if effective_lang == "en" {
         patch::build_copy_pairs_checked(&source_dir, &app_path)?

--- a/src-tauri/src/commands/apply.rs
+++ b/src-tauri/src/commands/apply.rs
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖 snapshot/status、English 原字节快照与 keyed JSON overlay、Program Files typed parent transaction、platform_runtime direct preflight、privilege copy completion 与 Unix PermissionsExt 模式比较。
- * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、生产与测试共用的 Windows English 原字节/三语 canonical overlay pair 构造、单次 UAC/typed cleanup warning、全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
- * [POS]: commands 的语言写入编排；Windows 让 English 恢复保留已验证快照原字节、翻译 payload 保持规范化，macOS 把 files_match 未改资产仍绑定到同一认证 generation，并在 state/transaction 提交前完成 runtime、签名与 quarantine，任一失败均回滚精确 bundle/state preimage。
+ * [OUTPUT]: 提供 apply_language_inner、仅对无 pending journal 的精确 Clean English 允许的 no-op、长度/只读位/Unix mode/内容感知的增量 pair 筛选、生产与测试共用的 Windows English 原字节/三语 canonical overlay pair 构造、English manifest entry SHA 到 UAC parent staging 的连续 evidence、单次 UAC/typed cleanup warning、全安装根 Cavalry-still-running error code、自定义根 fallback，以及 macOS English UI/官方还原、首装 launcher gate、全量 JSON observe-only postcondition、durable transaction、签名和 Gatekeeper 提交门。
+ * [POS]: commands 的语言写入编排；Windows 让 English 恢复保留已验证快照原字节并把验证证据传过 staging 边界、翻译 payload 保持规范化，macOS 把 files_match 未改资产仍绑定到同一认证 generation，并在 state/transaction 提交前完成 runtime、签名与 quarantine，任一失败均回滚精确 bundle/state preimage。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 use chrono::Utc;
@@ -435,6 +435,27 @@ pub fn apply_language_inner<R: CommandRunner>(
         current_language_source.as_deref(),
     )?;
 
+    #[cfg(target_os = "windows")]
+    let windows_english_manifest = if effective_lang == "en" {
+        let expected_manifest_sha256 = current_state
+            .english_snapshot_provenance
+            .as_ref()
+            .and_then(|provenance| provenance.snapshot_manifest_sha256.as_deref())
+            .ok_or_else(|| {
+                "Windows English restore requires a manifest-bound immutable snapshot.".to_string()
+            })?;
+        Some(
+            patch::validate_english_snapshot_at(
+                &english_snapshot_dir,
+                &app_path,
+                expected_manifest_sha256,
+            )?
+            .manifest,
+        )
+    } else {
+        None
+    };
+
     let staging_root = unique_staging_root();
     #[cfg(target_os = "macos")]
     let pairs = {
@@ -494,6 +515,7 @@ pub fn apply_language_inner<R: CommandRunner>(
                 cavalry_version: &version,
                 staging_root: &staging_root,
                 overlay_pairs: &pairs,
+                english_snapshot_manifest: windows_english_manifest.as_ref(),
             });
         if let Some(payload) = finish_program_files_result(
             program_files_result,

--- a/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
+++ b/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
@@ -7,13 +7,13 @@ contract.rs: 提权 plan v1 与固定退出码真相源；分别绑定 apply 的
 contract_tests.rs: plan/transport 纯合同测试；覆盖四语言 wire value、payload/QPA 绑定、apply/recovery reserved argv、有界输入与 fail-closed。
 transport.rs: 两类 ASCII-safe opaque token 编解码；apply 绑定 UTF-16LE plan path/hash/nonce/worker，recovery 只绑定 UTF-16LE install root/worker hash。
 launcher.rs: 父进程唯一 RunAs 边界；为 apply/recovery 构造各自固定单参数，通过 ShellExecuteExW 启动当前 EXE并结构化返回取消或 worker 退出码。
-parent.rs: 非提权父进程编排；在旧 close/copy 前识别 OS-known Program Files，严格 staging 固定 payload；仅当无 pending journal、全量目标与 QPA Noop 只读证明同时一致时零 UAC 提交，否则只调用一次 launcher 先恢复再应用，并把 45 投影为可重试 StillRunning，已启动后结果未知则保留绑定 staging。
+parent.rs: 非提权父进程编排；在旧 close/copy 前识别 OS-known Program Files，把已验证 English manifest entry SHA 与独占 source copy 连续比对并严格 staging 固定 payload；仅当无 pending journal、全量目标与 QPA Noop 只读证明同时一致时零 UAC 提交，否则只调用一次 launcher 先恢复再应用，并把 45 投影为可重试 StillRunning，已启动后结果未知则保留绑定 staging。
 parent_mapping.rs: 父进程 JSON 目标授权；只接受 CORE_MAP、当前存在的 PLUGIN_DEFINITION_MAP 与实时普通 plugin strings 对应的 assets-relative ID。
 parent_storage.rs: 父进程 staging/哈希与保守清理；来源以独占句柄复制并同步摘要，UAC 后只删除固定 plan、数字 payload、已绑定 overlay 与已知空目录。
-parent_tests.rs: 父进程隔离合同；覆盖 NotApplicable、取消、无 journal 的零 UAC Noop、pending journal 强制 worker、启动前清理、启动后 staging 保留、0/42/43/44/45/未知、严格映射与连续 marker preimage。
+parent_tests.rs: 父进程隔离合同；覆盖 NotApplicable、English manifest source 绑定、取消、无 journal 的零 UAC Noop、pending journal 强制 worker、启动前清理、启动后 staging 保留、0/42/43/44/45/未知、严格映射与连续 marker preimage。
 source_provenance.rs: worker 写入前的只读来源证明；从当前 EXE 有界上溯近邻包根，以编译期四语/runtime 摘要验证普通文件，非 English 重建 current→anchored English→target canonical overlay，English 则要求快照原字节解析值等于同一 anchored English postimage，并验证 QPA action。
 source_provenance_tests.rs: 来源证明对抗合同；覆盖自洽恶意 x64 DLL、字符串/marker 篡改、正确 overlay、四语 catalog 与缺失/重解析 package root。
-source_provenance_parent_tests.rs: commands 生产 pair 选择/parent/verifier 端到端合同；覆盖 zh-Hans→ja canonical overlay、Windows 非规范格式 English 快照原字节逐字节 staging 与 prepare 后篡改拒绝。
+source_provenance_parent_tests.rs: commands 生产 pair 选择/parent/verifier 端到端合同；覆盖 zh-Hans→ja canonical overlay、Windows 非规范格式 English 快照原字节逐字节 staging、pair 选择后同语义改写拒绝与 prepare 后篡改拒绝。
 path_validation.rs: live apply 与 recovery 共用的路径/摘要准入；将 install root containment、root/self 与 dot traversal 拒绝、逐组件 reparse 检查及 lowercase SHA-256 格式收敛为单一 fail-closed 合同。
 journal_manifest.rs: schema v3 版本化 `journal.state`/`.tmp` 崩溃恢复真相；manifest 以 no-share + OPEN_REPARSE_POINT 句柄读取/写入并严格验证每个 entry 的路径、pre/postimage、backup、权限、双向 displaced intent 与 phase；state 是已发布权威代，state.tmp 是提交候选，双代分歧时保守采用 state，state 缺失才接受完整 tmp，并决定下次启动的 commit/rollback/cleanup。
 storage.rs: worker durable journal 与 handle-bound CAS 编排；只消费写前声明的精确 postimage，正向/回滚 Replace 前持久化带 expected before/after 的 displaced intent，文件回滚前恢复由 preimage 证明的原始父目录，全部确定后才恢复 marker，未知当前内容永不覆盖。

--- a/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
+++ b/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
@@ -13,7 +13,7 @@ parent_storage.rs: 父进程 staging/哈希与保守清理；来源以独占句�
 parent_tests.rs: 父进程隔离合同；覆盖 NotApplicable、取消、无 journal 的零 UAC Noop、pending journal 强制 worker、启动前清理、启动后 staging 保留、0/42/43/44/45/未知、严格映射与连续 marker preimage。
 source_provenance.rs: worker 写入前的只读来源证明；从当前 EXE 有界上溯近邻包根，以编译期四语/runtime 摘要验证普通文件，非 English 重建 current→anchored English→target canonical overlay，English 则要求快照原字节解析值等于同一 anchored English postimage，并验证 QPA action。
 source_provenance_tests.rs: 来源证明对抗合同；覆盖自洽恶意 x64 DLL、字符串/marker 篡改、正确 overlay、四语 catalog 与缺失/重解析 package root。
-source_provenance_parent_tests.rs: patch/parent/verifier 端到端合同；覆盖 zh-Hans→ja canonical overlay、Windows English 快照原字节、真实数字 staging 与 prepare 后篡改拒绝。
+source_provenance_parent_tests.rs: commands 生产 pair 选择/parent/verifier 端到端合同；覆盖 zh-Hans→ja canonical overlay、Windows 非规范格式 English 快照原字节逐字节 staging 与 prepare 后篡改拒绝。
 path_validation.rs: live apply 与 recovery 共用的路径/摘要准入；将 install root containment、root/self 与 dot traversal 拒绝、逐组件 reparse 检查及 lowercase SHA-256 格式收敛为单一 fail-closed 合同。
 journal_manifest.rs: schema v3 版本化 `journal.state`/`.tmp` 崩溃恢复真相；manifest 以 no-share + OPEN_REPARSE_POINT 句柄读取/写入并严格验证每个 entry 的路径、pre/postimage、backup、权限、双向 displaced intent 与 phase；state 是已发布权威代，state.tmp 是提交候选，双代分歧时保守采用 state，state 缺失才接受完整 tmp，并决定下次启动的 commit/rollback/cleanup。
 storage.rs: worker durable journal 与 handle-bound CAS 编排；只消费写前声明的精确 postimage，正向/回滚 Replace 前持久化带 expected before/after 的 displaced intent，文件回滚前恢复由 preimage 证明的原始父目录，全部确定后才恢复 marker，未知当前内容永不覆盖。

--- a/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
+++ b/src-tauri/src/privilege/windows/language_transaction/CLAUDE.md
@@ -11,9 +11,9 @@ parent.rs: 非提权父进程编排；在旧 close/copy 前识别 OS-known Progr
 parent_mapping.rs: 父进程 JSON 目标授权；只接受 CORE_MAP、当前存在的 PLUGIN_DEFINITION_MAP 与实时普通 plugin strings 对应的 assets-relative ID。
 parent_storage.rs: 父进程 staging/哈希与保守清理；来源以独占句柄复制并同步摘要，UAC 后只删除固定 plan、数字 payload、已绑定 overlay 与已知空目录。
 parent_tests.rs: 父进程隔离合同；覆盖 NotApplicable、取消、无 journal 的零 UAC Noop、pending journal 强制 worker、启动前清理、启动后 staging 保留、0/42/43/44/45/未知、严格映射与连续 marker preimage。
-source_provenance.rs: worker 写入前的只读来源证明；从当前 EXE 有界上溯近邻包根，以编译期四语/runtime 摘要验证普通文件，重建 current→anchored English→target exact overlay 与 QPA action。
+source_provenance.rs: worker 写入前的只读来源证明；从当前 EXE 有界上溯近邻包根，以编译期四语/runtime 摘要验证普通文件，非 English 重建 current→anchored English→target canonical overlay，English 则要求快照原字节解析值等于同一 anchored English postimage，并验证 QPA action。
 source_provenance_tests.rs: 来源证明对抗合同；覆盖自洽恶意 x64 DLL、字符串/marker 篡改、正确 overlay、四语 catalog 与缺失/重解析 package root。
-source_provenance_parent_tests.rs: patch/parent/verifier 端到端合同；覆盖 zh-Hans→ja、Windows canonical English、真实数字 staging 与 prepare 后篡改拒绝。
+source_provenance_parent_tests.rs: patch/parent/verifier 端到端合同；覆盖 zh-Hans→ja canonical overlay、Windows English 快照原字节、真实数字 staging 与 prepare 后篡改拒绝。
 path_validation.rs: live apply 与 recovery 共用的路径/摘要准入；将 install root containment、root/self 与 dot traversal 拒绝、逐组件 reparse 检查及 lowercase SHA-256 格式收敛为单一 fail-closed 合同。
 journal_manifest.rs: schema v3 版本化 `journal.state`/`.tmp` 崩溃恢复真相；manifest 以 no-share + OPEN_REPARSE_POINT 句柄读取/写入并严格验证每个 entry 的路径、pre/postimage、backup、权限、双向 displaced intent 与 phase；state 是已发布权威代，state.tmp 是提交候选，双代分歧时保守采用 state，state 缺失才接受完整 tmp，并决定下次启动的 commit/rollback/cleanup。
 storage.rs: worker durable journal 与 handle-bound CAS 编排；只消费写前声明的精确 postimage，正向/回滚 Replace 前持久化带 expected before/after 的 displaced intent，文件回滚前恢复由 preimage 证明的原始父目录，全部确定后才恢复 marker，未知当前内容永不覆盖。

--- a/src-tauri/src/privilege/windows/language_transaction/parent.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/parent.rs
@@ -1,10 +1,11 @@
 /**
- * [INPUT]: 依赖 OS-known Program Files、固定 JSON 映射、Windows runtime 打包源、QPA transition 合同与 same-EXE RunAs launcher。
- * [OUTPUT]: 提供 Program Files 早分流、严格 payload staging、English cleanup 的当前 generic 所有权输入、仅在无 pending journal 时成立的 Noop 快路与单次 UAC typed 结果。
- * [POS]: language_transaction 的非提权父进程；只准备 hash-locked 计划并等待 worker，绝不关闭 Cavalry、写状态、重启或直接修改安装根。
+ * [INPUT]: 依赖 OS-known Program Files、固定 JSON 映射、已验证 English snapshot manifest entry SHA、Windows runtime 打包源、QPA transition 合同与 same-EXE RunAs launcher。
+ * [OUTPUT]: 提供 Program Files 早分流、manifest-bound English 独占读取/staging、严格 payload staging、English cleanup 的当前 generic 所有权输入、仅在无 pending journal 时成立的 Noop 快路与单次 UAC typed 结果。
+ * [POS]: language_transaction 的非提权父进程；把内存中的快照 evidence 连续绑定到 hash-locked 计划并等待 worker，绝不关闭 Cavalry、写状态、重启或直接修改安装根。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 use std::{
+    collections::HashMap,
     fmt, fs,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
@@ -13,7 +14,7 @@ use std::{
 
 use crate::{
     install::{InstallLayout, InstallPlatform},
-    patch::CopyPair,
+    patch::{CopyPair, EnglishSnapshotManifest},
     windows_qpa::{
         self, ActivationRequest, QpaDeploymentState, QpaNoopReason, QpaTransitionPlan,
         RestoreReason, RestoreRequest, GENERIC_PLUGIN_RELATIVE_PATH,
@@ -61,6 +62,7 @@ pub(crate) struct ParentApplyRequest<'a> {
     pub(crate) cavalry_version: &'a str,
     pub(crate) staging_root: &'a Path,
     pub(crate) overlay_pairs: &'a [CopyPair],
+    pub(crate) english_snapshot_manifest: Option<&'a EnglishSnapshotManifest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -371,6 +373,7 @@ where
         Option<&Path>,
     ) -> Result<QpaTransitionPlan, String>,
 {
+    let expected_english_hashes = expected_english_source_hashes(request, language, &classified)?;
     let worker_hash = sha256_file(current_exe).map_err(rejected)?;
     let nonce = next_plan_nonce(current_exe, request.staging_root, &worker_hash);
     let directory = request
@@ -408,6 +411,25 @@ where
                 Some(pair.destination),
                 preimage,
             )?;
+            if let Some(expected_hashes) = expected_english_hashes.as_ref() {
+                let expected = expected_hashes.get(&pair.id).ok_or_else(|| {
+                    format!(
+                        "English snapshot manifest has no staging evidence for {}.",
+                        pair.id
+                    )
+                })?;
+                let actual = &payloads
+                    .last()
+                    .ok_or_else(|| "English payload staging produced no record.".to_string())?
+                    .record
+                    .source_sha256;
+                if actual != expected {
+                    return Err(format!(
+                        "English snapshot bytes changed before elevated staging for {}.",
+                        pair.id
+                    ));
+                }
+            }
         }
 
         let mut staged_generic = None;
@@ -480,6 +502,56 @@ where
     })();
 
     result.map_err(|error: String| cleanup_rejected(request.staging_root, &directory, error))
+}
+
+fn expected_english_source_hashes(
+    request: &ParentApplyRequest<'_>,
+    language: Language,
+    classified: &[ClassifiedPair],
+) -> Result<Option<HashMap<String, String>>, ParentApplyError> {
+    if language != Language::English {
+        if request.english_snapshot_manifest.is_some() {
+            return Err(rejected(
+                "Non-English elevated staging must not carry English snapshot evidence.",
+            ));
+        }
+        return Ok(None);
+    }
+
+    let manifest = request.english_snapshot_manifest.ok_or_else(|| {
+        rejected("English elevated staging requires verified snapshot manifest evidence.")
+    })?;
+    let mut hashes = HashMap::with_capacity(manifest.entries.len());
+    for entry in &manifest.entries {
+        if entry.sha256.len() != 64
+            || !entry
+                .sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(rejected(format!(
+                "English snapshot manifest has an invalid SHA-256 for {}.",
+                entry.asset_relative_path
+            )));
+        }
+        if hashes
+            .insert(entry.asset_relative_path.clone(), entry.sha256.clone())
+            .is_some()
+        {
+            return Err(rejected(format!(
+                "English snapshot manifest repeats asset identity {}.",
+                entry.asset_relative_path
+            )));
+        }
+    }
+    if hashes.len() != classified.len()
+        || classified.iter().any(|pair| !hashes.contains_key(&pair.id))
+    {
+        return Err(rejected(
+            "English snapshot manifest does not match the complete elevated asset surface.",
+        ));
+    }
+    Ok(Some(hashes))
 }
 
 fn build_qpa_transition(

--- a/src-tauri/src/privilege/windows/language_transaction/parent_tests.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/parent_tests.rs
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 parent 的可注入 QPA/launcher/postcondition seam 与 tempfile Windows fixture。
- * [OUTPUT]: 覆盖 Program Files 早分流、严格目标映射、仅在无 journal 时成立的 AlreadyStock 零 UAC、pending journal 强制 worker、单次 UAC、取消零目标写入、source provenance E2E 及 0/42/43/44/45/未知退出语义。
+ * [INPUT]: 依赖 parent 的可注入 QPA/launcher/postcondition seam、English snapshot manifest evidence 与 tempfile Windows fixture。
+ * [OUTPUT]: 覆盖 Program Files 早分流、严格目标映射、English source SHA 绑定、仅在无 journal 时成立的 AlreadyStock 零 UAC、pending journal 强制 worker、单次 UAC、取消零目标写入、source provenance E2E 及 0/42/43/44/45/未知退出语义。
  * [POS]: language_transaction parent 的隔离合同测试；不调用真实 UAC、不写真实 Program Files，并挂接真实 patch→stage→verifier 子合同。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -12,7 +12,9 @@ use std::{
 
 use super::*;
 use crate::install::LANG_MARKER_NAME;
-use crate::patch::CORE_MAP;
+use crate::patch::{
+    EnglishSnapshotEntry, EnglishSnapshotManifest, CORE_MAP, ENGLISH_SNAPSHOT_SCHEMA_VERSION,
+};
 use crate::windows_qpa::{
     QpaActivationPlan, QpaNoopPlan, QpaNoopReason, QpaTransitionPlan, SUPPORTED_ARCHITECTURE,
     SUPPORTED_CAVALRY_VERSION, SUPPORTED_QT_VERSION,
@@ -28,6 +30,7 @@ struct Fixture {
     proxy: PathBuf,
     generic: PathBuf,
     pairs: Vec<CopyPair>,
+    english_manifest: EnglishSnapshotManifest,
 }
 
 impl Fixture {
@@ -58,6 +61,19 @@ impl Fixture {
                 dst: destination,
             });
         }
+        let english_manifest = EnglishSnapshotManifest {
+            schema_version: ENGLISH_SNAPSHOT_SCHEMA_VERSION,
+            entries: pairs
+                .iter()
+                .enumerate()
+                .map(|(index, pair)| EnglishSnapshotEntry {
+                    language_relative_path: format!("fixture/{index}.json"),
+                    asset_relative_path: CORE_MAP[index].1.to_string(),
+                    sha256: hex_digest(&fs::read(&pair.src).unwrap()),
+                    unix_mode: None,
+                })
+                .collect(),
+        };
 
         let worker_exe = temp.path().join("switcher.exe");
         fs::write(&worker_exe, b"switcher").unwrap();
@@ -75,6 +91,7 @@ impl Fixture {
             proxy,
             generic,
             pairs,
+            english_manifest,
         }
     }
 
@@ -88,6 +105,7 @@ impl Fixture {
             cavalry_version: "2.7.2",
             staging_root: &self.staging,
             overlay_pairs: &self.pairs,
+            english_snapshot_manifest: (language == "en").then_some(&self.english_manifest),
         }
     }
 

--- a/src-tauri/src/privilege/windows/language_transaction/source_provenance.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/source_provenance.rs
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 build.rs 编译期嵌入的四语/Windows runtime SHA-256、固定 payload schema、JSON overlay 规则与 QPA transition planner。
- * [OUTPUT]: 提供 worker 写前 provenance 证明；写入 payload 必须锚定当前发布，English 删除计划则从 ACL 保护的 live manifest 精确重建以兼容旧发行残留。
+ * [INPUT]: 依赖 build.rs 编译期嵌入的四语/Windows runtime SHA-256、固定 payload schema、JSON keyed overlay 语义与 QPA transition planner。
+ * [OUTPUT]: 提供 worker 写前 provenance 证明；非 English payload 必须等于当前发布的 canonical merge，English payload 保留快照原字节但其解析值必须等于 anchored English postimage，删除计划则从 ACL 保护的 live manifest 精确重建以兼容旧发行残留。
  * [POS]: language_transaction 的只读信任边界；区分“当前包可写字节”与“历史 manifest 可删所有权”，在关闭 Cavalry 与安装根写入前 fail closed。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -297,18 +297,25 @@ fn verify_json_payload(
     let translation: Value = serde_json::from_slice(&translation_bytes)
         .map_err(|error| format!("Packaged language JSON is invalid: {error}"))?;
     let english_baseline = merge_translation_overlay(&installed, &english);
-    let rebuilt =
-        serde_json::to_vec_pretty(&merge_translation_overlay(&english_baseline, &translation))
-            .map_err(|error| format!("Could not rebuild trusted language overlay: {error}"))?;
     let staged = read_locked_bounded(
         staging_root,
         source,
         MAX_JSON_BYTES,
         "staged language overlay",
     )?;
-    if staged != rebuilt || sha256_bytes(&staged) != record.source_sha256 {
+    let trusted = if language == Language::English {
+        serde_json::from_slice::<Value>(&staged)
+            .map_err(|error| format!("Staged English snapshot JSON is invalid: {error}"))?
+            == english_baseline
+    } else {
+        let rebuilt =
+            serde_json::to_vec_pretty(&merge_translation_overlay(&english_baseline, &translation))
+                .map_err(|error| format!("Could not rebuild trusted language overlay: {error}"))?;
+        staged == rebuilt
+    };
+    if !trusted || sha256_bytes(&staged) != record.source_sha256 {
         return Err(format!(
-            "Staged language overlay {} is not the exact trusted merge result.",
+            "Staged language payload {} is not the trusted target result.",
             record.id
         ));
     }

--- a/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 patch::build_overlay_pairs、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
- * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP/English 的真实 parent staged bytes 被 verifier 精确接受，且同一 staged payload 篡改后被拒绝。
+ * [INPUT]: 依赖 patch::build_copy_pairs_checked/build_overlay_pairs、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
+ * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP 的 canonical overlay 与 English 快照原字节经真实 parent staging 后都被 verifier 接受，且同一 staged payload 篡改后被拒绝。
  * [POS]: parent tests 的端到端来源合同；连接上游 canonical overlay、数字 payload staging 与提权 worker 只读 provenance，不模拟复制算法。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -38,7 +38,7 @@ fn real_parent_staging_accepts_cross_language_zh_hans_to_japanese() {
 }
 
 #[test]
-fn real_parent_staging_accepts_canonical_explicit_english() {
+fn real_parent_staging_accepts_exact_english_snapshot_bytes() {
     let fixture = ProvenanceFixture::new();
     let prepared = fixture.prepare(Language::English);
 
@@ -189,16 +189,20 @@ impl ProvenanceFixture {
             }
             source
         };
-        let target_pairs = patch::build_overlay_pairs(
-            &source_dir,
-            &self.state_dir.join("en"),
-            &self.layout.root,
-            &self
-                ._temp
-                .path()
-                .join(format!("target-overlay-{}", language.as_str())),
-        )
-        .unwrap();
+        let target_pairs = if language == Language::English {
+            patch::build_copy_pairs_checked(&source_dir, &self.layout.root).unwrap()
+        } else {
+            patch::build_overlay_pairs(
+                &source_dir,
+                &self.state_dir.join("en"),
+                &self.layout.root,
+                &self
+                    ._temp
+                    .path()
+                    .join(format!("target-overlay-{}", language.as_str())),
+            )
+            .unwrap()
+        };
         assert_eq!(target_pairs.len(), CORE_MAP.len());
         let request = ParentApplyRequest {
             repo_root: &self.package_root,

--- a/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 依赖 patch::build_copy_pairs_checked/build_overlay_pairs、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
- * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP 的 canonical overlay 与 English 快照原字节经真实 parent staging 后都被 verifier 接受，且同一 staged payload 篡改后被拒绝。
- * [POS]: parent tests 的端到端来源合同；连接上游 canonical overlay、数字 payload staging 与提权 worker 只读 provenance，不模拟复制算法。
+ * [INPUT]: 依赖 commands 生产 Windows pair 构造、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
+ * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP 的 canonical overlay 与非规范格式 English 快照原字节经真实生产选择及 parent staging 后都被 verifier 接受并逐字节保真，且同一 staged payload 篡改后被拒绝。
+ * [POS]: parent tests 的端到端来源合同；连接生产语言分支、数字 payload staging 与提权 worker 只读 provenance，不在 fixture 中复制 pair 选择算法。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 use std::{
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::{
+    commands::build_windows_language_pairs,
     install::InstallLayout,
     patch::{self, CORE_MAP},
 };
@@ -41,6 +42,27 @@ fn real_parent_staging_accepts_cross_language_zh_hans_to_japanese() {
 fn real_parent_staging_accepts_exact_english_snapshot_bytes() {
     let fixture = ProvenanceFixture::new();
     let prepared = fixture.prepare(Language::English);
+
+    let snapshot = fixture.state_dir.join("en").join(CORE_MAP[0].0);
+    let snapshot_bytes = fs::read(&snapshot).unwrap();
+    let parsed = serde_json::from_slice::<serde_json::Value>(&snapshot_bytes).unwrap();
+    assert_ne!(
+        snapshot_bytes,
+        serde_json::to_vec_pretty(&parsed).unwrap(),
+        "fixture must retain non-canonical English bytes"
+    );
+    let asset_index = prepared
+        .plan
+        .payloads
+        .iter()
+        .position(|record| record.kind == PayloadKind::CoreAsset && record.id == CORE_MAP[0].1)
+        .unwrap();
+    let staged = payload_source_path(&prepared.plan_path, asset_index).unwrap();
+    assert_eq!(
+        fs::read(staged).unwrap(),
+        snapshot_bytes,
+        "English staging must preserve immutable snapshot bytes exactly"
+    );
 
     verify_payload_records_for_test(
         &prepared.plan,
@@ -189,20 +211,17 @@ impl ProvenanceFixture {
             }
             source
         };
-        let target_pairs = if language == Language::English {
-            patch::build_copy_pairs_checked(&source_dir, &self.layout.root).unwrap()
-        } else {
-            patch::build_overlay_pairs(
-                &source_dir,
-                &self.state_dir.join("en"),
-                &self.layout.root,
-                &self
-                    ._temp
-                    .path()
-                    .join(format!("target-overlay-{}", language.as_str())),
-            )
-            .unwrap()
-        };
+        let target_pairs = build_windows_language_pairs(
+            language.as_str(),
+            &source_dir,
+            &self.state_dir.join("en"),
+            &self.layout.root,
+            &self
+                ._temp
+                .path()
+                .join(format!("target-overlay-{}", language.as_str())),
+        )
+        .unwrap();
         assert_eq!(target_pairs.len(), CORE_MAP.len());
         let request = ParentApplyRequest {
             repo_root: &self.package_root,

--- a/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
+++ b/src-tauri/src/privilege/windows/language_transaction/source_provenance_parent_tests.rs
@@ -1,7 +1,7 @@
 /**
- * [INPUT]: 依赖 commands 生产 Windows pair 构造、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
- * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP 的 canonical overlay 与非规范格式 English 快照原字节经真实生产选择及 parent staging 后都被 verifier 接受并逐字节保真，且同一 staged payload 篡改后被拒绝。
- * [POS]: parent tests 的端到端来源合同；连接生产语言分支、数字 payload staging 与提权 worker 只读 provenance，不在 fixture 中复制 pair 选择算法。
+ * [INPUT]: 依赖 commands 生产 Windows pair 构造、已验证 English manifest entry SHA、parent 真实 classify/prepare/stage 路径、编译期 catalog 与 source_provenance test seam。
+ * [OUTPUT]: 证明 zh-Hans 当前态到 ja_JP 的 canonical overlay 与非规范格式 English 快照原字节经真实生产选择及 parent staging 后都被 verifier 接受并逐字节保真，pair 选择后的同语义字节替换和 prepare 后 staged 篡改均被拒绝。
+ * [POS]: parent tests 的端到端来源合同；连接生产语言分支、manifest evidence、数字 payload staging 与提权 worker 只读 provenance，不在 fixture 中复制 pair 选择算法。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 use std::{
@@ -12,8 +12,12 @@ use std::{
 use crate::{
     commands::build_windows_language_pairs,
     install::InstallLayout,
-    patch::{self, CORE_MAP},
+    patch::{
+        self, EnglishSnapshotEntry, EnglishSnapshotManifest, CORE_MAP,
+        ENGLISH_SNAPSHOT_SCHEMA_VERSION,
+    },
 };
+use sha2::{Digest, Sha256};
 
 use super::{
     super::{classify_overlay_pairs, prepare_parent_plan, ParentApplyRequest, RuntimeSources},
@@ -74,9 +78,37 @@ fn real_parent_staging_accepts_exact_english_snapshot_bytes() {
 }
 
 #[test]
+fn real_parent_staging_rejects_english_snapshot_reformatted_after_pair_selection() {
+    let fixture = ProvenanceFixture::new();
+    let result = fixture.try_prepare_after_pair_selection(Language::English, |pairs| {
+        let source = &pairs[0].src;
+        let original = fs::read(source).unwrap();
+        let parsed = serde_json::from_slice::<serde_json::Value>(&original).unwrap();
+        let reformatted = serde_json::to_vec_pretty(&parsed).unwrap();
+        assert_ne!(original, reformatted);
+        fs::write(source, reformatted).unwrap();
+    });
+
+    let rejected = match result {
+        Err(_) => true,
+        Ok(prepared) => verify_payload_records_for_test(
+            &prepared.plan,
+            &prepared.plan_path,
+            &fixture.layout,
+            &fixture.package_root,
+        )
+        .is_err(),
+    };
+    assert!(
+        rejected,
+        "English bytes changed after pair selection must not become a trusted elevated payload"
+    );
+}
+
+#[test]
 fn real_parent_staging_rejects_post_prepare_payload_tampering() {
     let fixture = ProvenanceFixture::new();
-    let prepared = fixture.prepare(Language::Japanese);
+    let prepared = fixture.prepare(Language::English);
     let asset_index = prepared
         .plan
         .payloads
@@ -104,6 +136,9 @@ struct ProvenanceFixture {
     state_dir: PathBuf,
     staging_root: PathBuf,
     worker_executable: PathBuf,
+    english_manifest: EnglishSnapshotManifest,
+    generic_source: PathBuf,
+    qpa_source: PathBuf,
 }
 
 impl ProvenanceFixture {
@@ -137,6 +172,16 @@ impl ProvenanceFixture {
                 &package_root.join(relative),
             );
         }
+        let generic_source = temp.path().join("runtime-sources/generic.bin");
+        let qpa_source = temp.path().join("runtime-sources/qpa.bin");
+        copy_file(
+            &repository_root.join("injector/windows/generic/cavalryi18n.dll"),
+            &generic_source,
+        );
+        copy_file(
+            &repository_root.join("injector/windows/qpa/qwindows.dll"),
+            &qpa_source,
+        );
         let install_root = temp.path().join("Program Files/Cavalry");
         fs::create_dir_all(&install_root).unwrap();
         let layout = InstallLayout::from_root(&fs::canonicalize(install_root).unwrap());
@@ -165,6 +210,21 @@ impl ProvenanceFixture {
                 &current_source.join(language_relative),
             );
         }
+        let english_manifest = EnglishSnapshotManifest {
+            schema_version: ENGLISH_SNAPSHOT_SCHEMA_VERSION,
+            entries: CORE_MAP
+                .iter()
+                .map(|(language_relative, asset_relative)| {
+                    let bytes = fs::read(state_dir.join("en").join(language_relative)).unwrap();
+                    EnglishSnapshotEntry {
+                        language_relative_path: (*language_relative).to_string(),
+                        asset_relative_path: (*asset_relative).to_string(),
+                        sha256: format!("{:x}", Sha256::digest(bytes)),
+                        unix_mode: None,
+                    }
+                })
+                .collect(),
+        };
         let current_pairs = patch::build_overlay_pairs(
             &current_source,
             &state_dir.join("en"),
@@ -188,10 +248,25 @@ impl ProvenanceFixture {
             state_dir,
             staging_root,
             worker_executable,
+            english_manifest,
+            generic_source,
+            qpa_source,
         }
     }
 
     fn prepare(&self, language: Language) -> super::super::PreparedParentPlan {
+        self.try_prepare_after_pair_selection(language, |_| {})
+            .unwrap()
+    }
+
+    fn try_prepare_after_pair_selection<F>(
+        &self,
+        language: Language,
+        after_pair_selection: F,
+    ) -> Result<super::super::PreparedParentPlan, super::super::ParentApplyError>
+    where
+        F: FnOnce(&[patch::CopyPair]),
+    {
         let source_dir = if language == Language::English {
             self.state_dir.join("en")
         } else {
@@ -223,6 +298,7 @@ impl ProvenanceFixture {
         )
         .unwrap();
         assert_eq!(target_pairs.len(), CORE_MAP.len());
+        after_pair_selection(&target_pairs);
         let request = ParentApplyRequest {
             repo_root: &self.package_root,
             resource_dir: &self.package_root,
@@ -232,14 +308,13 @@ impl ProvenanceFixture {
             cavalry_version: "2.7.2",
             staging_root: &self.staging_root,
             overlay_pairs: &target_pairs,
+            english_snapshot_manifest: (language == Language::English)
+                .then_some(&self.english_manifest),
         };
         let classified = classify_overlay_pairs(&self.layout, &target_pairs).unwrap();
         let runtime_sources = RuntimeSources {
-            generic: {
-                self.package_root
-                    .join("injector/windows/generic/cavalryi18n.dll")
-            },
-            proxy: self.package_root.join("injector/windows/qpa/qwindows.dll"),
+            generic: self.generic_source.clone(),
+            proxy: self.qpa_source.clone(),
         };
         prepare_parent_plan(
             &request,
@@ -249,7 +324,6 @@ impl ProvenanceFixture {
             classified,
             &mut synthetic_transition,
         )
-        .unwrap()
     }
 }
 


### PR DESCRIPTION
## Summary

- Restore Windows English assets from the immutable snapshot's exact bytes instead of rebuilding them through the canonical pretty-overlay path.
- Keep Simplified Chinese, Traditional Chinese, and Japanese on the existing canonical overlay path.
- Preserve the Program Files trust boundary: the elevated worker accepts English bytes only when their parsed JSON equals the anchored current-to-English postimage and their SHA-256 matches the staged plan.
- Add a real parent-staging regression contract and align L1/L2/L3 documentation with the split English/non-English behavior.

## Verification

- Node.js `24.20.0`; npm `11.19.0`.
- `npm run check:app` passed.
- `npm run check:version` passed.
- `npm run check:release` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib -- --test-threads=1`: 249 passed.
- Disposable real Cavalry 2.7.2 clone smoke: three target languages applied, then English restored; 1/1 passed with all mapped English resources restored byte-for-byte.
- `npm run test:contracts`: 224/225 passed in the non-elevated shell; the sole test stopped during fixture setup because Windows denied symlink creation (`EPERM`) before product assertions.

Advances #16