### PR TITLE
fix(windows): recreate live acceptance plugin directory

### DIFF
--- a/src-tauri/tests/support/CLAUDE.md
+++ b/src-tauri/tests/support/CLAUDE.md
@@ -6,7 +6,7 @@ windows_disposable.rs: Windows ignored smoke 的共享路径安全边界；只�
 windows_clone_guard.rs: Windows live clone 的关键资源安全边界；启动前检查 `assets/Icons/sign-in-bg.png`、`cavByCanva.png`、`tool_search.png` 为非空普通文件并把字节哈希写入 evidence；不读取、不写入真实用户 profile。
 windows_live_capture.inc.rs: Windows live smoke 的公共捕获分片；定义 exact-PID helper 协议、Onboarding 五步 ready/ack、主窗截图封存与共享证据数据结构（含 PID/HWND）；cleanup 先投递 WM_CLOSE，超时只对再次复核的同 executable/PID ForceStop。
 windows_live_adjacent.inc.rs: Adjacent 消费者协议分片；独立复核 Tag/Assets 三语 oracle、write-once ready/ack/done、双动态 stem、producer PNG 与两逻辑点完整性。
-windows_live_orchestration.inc.rs: live-clone 事务编排分片；管理语言 apply、FullSurfaces 的 TEMP-owned profile、仅 Onboarding/Adjacent 使用的 Qt test profile、可在 English 清理移除空目录后安全重建 `generic/` 的 acceptance-only plugin 临时安装、exact-PID/HWND 进程清理、English 字节恢复，并把 `tools/macos-acceptance/fixtures` 的两枚最小 PNG 作为双平台 Assets producer 输入冻结到每语唯一 stem。
+windows_live_orchestration.inc.rs: live-clone 事务编排分片；管理语言 apply、FullSurfaces 的 TEMP-owned profile、仅 Onboarding/Adjacent 使用的 Qt test profile、可在 English 清理移除空目录后安全重建 `generic/` 并仅回收本次创建目录的 acceptance-only plugin 临时事务、exact-PID/HWND 进程清理、English 字节恢复，并把 `tools/macos-acceptance/fixtures` 的两枚最小 PNG 作为双平台 Assets producer 输入冻结到每语唯一 stem。
 windows_live_toolchain.inc.rs: release machine record 的 Windows 工具链命令边界；优先以活动 Node 执行 `npm_execpath`，仅在缺失时用固定 `cmd.exe` 命令解析 PATH shim，兼容 MSI、Volta 等安装布局并提供红绿回归门。
 windows_live_tests.inc.rs: Windows live 门入口分片；冻结 helper/driver 禁用原语、profile/Next 转场/清理顺序，在每个 disposable gate 前调用 clone 关键资源 hash guard，并暴露 FullSurfaces、Onboarding、Adjacent 三个 ignored 人工像素复核门；显式 release 环境下只在清理成功后调用 toolchain 分片写入 machine record/inventory，绝不写人工 PASS。
 

--- a/src-tauri/tests/support/CLAUDE.md
+++ b/src-tauri/tests/support/CLAUDE.md
@@ -6,7 +6,7 @@ windows_disposable.rs: Windows ignored smoke 的共享路径安全边界；只�
 windows_clone_guard.rs: Windows live clone 的关键资源安全边界；启动前检查 `assets/Icons/sign-in-bg.png`、`cavByCanva.png`、`tool_search.png` 为非空普通文件并把字节哈希写入 evidence；不读取、不写入真实用户 profile。
 windows_live_capture.inc.rs: Windows live smoke 的公共捕获分片；定义 exact-PID helper 协议、Onboarding 五步 ready/ack、主窗截图封存与共享证据数据结构（含 PID/HWND）；cleanup 先投递 WM_CLOSE，超时只对再次复核的同 executable/PID ForceStop。
 windows_live_adjacent.inc.rs: Adjacent 消费者协议分片；独立复核 Tag/Assets 三语 oracle、write-once ready/ack/done、双动态 stem、producer PNG 与两逻辑点完整性。
-windows_live_orchestration.inc.rs: live-clone 事务编排分片；管理语言 apply、FullSurfaces 的 TEMP-owned profile、仅 Onboarding/Adjacent 使用的 Qt test profile、acceptance-only plugin 临时安装、exact-PID/HWND 进程清理、English 字节恢复，并把 `tools/macos-acceptance/fixtures` 的两枚最小 PNG 作为双平台 Assets producer 输入冻结到每语唯一 stem。
+windows_live_orchestration.inc.rs: live-clone 事务编排分片；管理语言 apply、FullSurfaces 的 TEMP-owned profile、仅 Onboarding/Adjacent 使用的 Qt test profile、可在 English 清理移除空目录后安全重建 `generic/` 的 acceptance-only plugin 临时安装、exact-PID/HWND 进程清理、English 字节恢复，并把 `tools/macos-acceptance/fixtures` 的两枚最小 PNG 作为双平台 Assets producer 输入冻结到每语唯一 stem。
 windows_live_toolchain.inc.rs: release machine record 的 Windows 工具链命令边界；优先以活动 Node 执行 `npm_execpath`，仅在缺失时用固定 `cmd.exe` 命令解析 PATH shim，兼容 MSI、Volta 等安装布局并提供红绿回归门。
 windows_live_tests.inc.rs: Windows live 门入口分片；冻结 helper/driver 禁用原语、profile/Next 转场/清理顺序，在每个 disposable gate 前调用 clone 关键资源 hash guard，并暴露 FullSurfaces、Onboarding、Adjacent 三个 ignored 人工像素复核门；显式 release 环境下只在清理成功后调用 toolchain 分片写入 machine record/inventory，绝不写人工 PASS。
 

--- a/src-tauri/tests/support/windows_live_orchestration.inc.rs
+++ b/src-tauri/tests/support/windows_live_orchestration.inc.rs
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖安装布局、语言 apply、English baseline、Onboarding/Adjacent 专用 Qt 测试 profile、TEMP-owned FullSurfaces profile、acceptance-only plugin 字节、clone guard、tools/macos-acceptance/fixtures 的双平台 Assets 媒体与 exact-PID/HWND 清理
- * [OUTPUT]: 在父测试模块内提供语言安装/验证、现场启动、验收插件临时部署、三语编排、WM_CLOSE/ForceStop 清理与 English 恢复
- * [POS]: src-tauri/tests/support 的 live-clone 事务编排分片；FullSurfaces launch 覆盖到 run-root 下的 disposable TEMP profile，Onboarding/Adjacent 使用 sentinel-owned qttest，所有 clone/evidence 写入均经过 disposable TEMP 根与 reparse 守卫
+ * [OUTPUT]: 在父测试模块内提供语言安装/验证、现场启动、可重建缺失 generic 目录的验收插件临时部署、三语编排、WM_CLOSE/ForceStop 清理与 English 恢复
+ * [POS]: src-tauri/tests/support 的 live-clone 事务编排分片；FullSurfaces launch 覆盖到 run-root 下的 disposable TEMP profile，Onboarding/Adjacent 使用 sentinel-owned qttest，并允许已恢复 English 的 clone 在受守卫目录中重复安装验收插件；所有 clone/evidence 写入均经过 disposable TEMP 根与 reparse 守卫
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
     fn find_node_type<'a>(
@@ -480,7 +480,27 @@
                 source.display()
             ));
         }
-        let destination = layout.root.join("generic/cavalryi18n_acceptance.dll");
+        let plugin_directory = layout.root.join("generic");
+        guarded_clone.assert_write_target(&plugin_directory)?;
+        match fs::create_dir(&plugin_directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if !plugin_directory.is_dir() {
+                    return Err(format!(
+                        "refusing non-directory Windows generic plugin path {}",
+                        plugin_directory.display()
+                    ));
+                }
+            }
+            Err(error) => {
+                return Err(format!(
+                    "could not create Windows generic plugin directory {}: {error}",
+                    plugin_directory.display()
+                ));
+            }
+        }
+        guarded_clone.assert_write_target(&plugin_directory)?;
+        let destination = plugin_directory.join("cavalryi18n_acceptance.dll");
         guarded_clone.assert_write_target(&destination)?;
         let bytes = fs::read(&source).map_err(|error| {
             format!(

--- a/src-tauri/tests/support/windows_live_orchestration.inc.rs
+++ b/src-tauri/tests/support/windows_live_orchestration.inc.rs
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖安装布局、语言 apply、English baseline、Onboarding/Adjacent 专用 Qt 测试 profile、TEMP-owned FullSurfaces profile、acceptance-only plugin 字节、clone guard、tools/macos-acceptance/fixtures 的双平台 Assets 媒体与 exact-PID/HWND 清理
- * [OUTPUT]: 在父测试模块内提供语言安装/验证、现场启动、可重建缺失 generic 目录的验收插件临时部署、三语编排、WM_CLOSE/ForceStop 清理与 English 恢复
- * [POS]: src-tauri/tests/support 的 live-clone 事务编排分片；FullSurfaces launch 覆盖到 run-root 下的 disposable TEMP profile，Onboarding/Adjacent 使用 sentinel-owned qttest，并允许已恢复 English 的 clone 在受守卫目录中重复安装验收插件；所有 clone/evidence 写入均经过 disposable TEMP 根与 reparse 守卫
+ * [OUTPUT]: 在父测试模块内提供语言安装/验证、现场启动、可重建并按原始拓扑清理缺失 generic 目录的验收插件临时部署、三语编排、WM_CLOSE/ForceStop 清理与 English 恢复
+ * [POS]: src-tauri/tests/support 的 live-clone 事务编排分片；FullSurfaces launch 覆盖到 run-root 下的 disposable TEMP profile，Onboarding/Adjacent 使用 sentinel-owned qttest，并允许已恢复 English 的 clone 在受守卫目录中重复安装验收插件且不遗留测试创建的目录；所有 clone/evidence 写入均经过 disposable TEMP 根与 reparse 守卫
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
     fn find_node_type<'a>(
@@ -470,7 +470,7 @@
         repo: &Path,
         layout: &InstallLayout,
         guarded_clone: &GuardedTempRoot,
-    ) -> Result<PathBuf, String> {
+    ) -> Result<(PathBuf, bool), String> {
         let source = repo.join(
             "build/windows-injector/acceptance/generic/cavalryi18n_acceptance.dll",
         );
@@ -482,8 +482,8 @@
         }
         let plugin_directory = layout.root.join("generic");
         guarded_clone.assert_write_target(&plugin_directory)?;
-        match fs::create_dir(&plugin_directory) {
-            Ok(()) => {}
+        let plugin_directory_created = match fs::create_dir(&plugin_directory) {
+            Ok(()) => true,
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 if !plugin_directory.is_dir() {
                     return Err(format!(
@@ -491,6 +491,7 @@
                         plugin_directory.display()
                     ));
                 }
+                false
             }
             Err(error) => {
                 return Err(format!(
@@ -498,7 +499,7 @@
                     plugin_directory.display()
                 ));
             }
-        }
+        };
         guarded_clone.assert_write_target(&plugin_directory)?;
         let destination = plugin_directory.join("cavalryi18n_acceptance.dll");
         guarded_clone.assert_write_target(&destination)?;
@@ -571,35 +572,48 @@
                 destination.display()
             ));
         }
-        Ok(destination)
+        Ok((destination, plugin_directory_created))
     }
 
     fn remove_acceptance_plugin(
         guarded_clone: &GuardedTempRoot,
         path: &Path,
+        plugin_directory_created: bool,
     ) -> Result<(), String> {
         guarded_clone.assert_write_target(path)?;
-        if !path.exists() {
-            return Ok(());
+        if path.exists() {
+            let metadata = fs::symlink_metadata(path).map_err(|error| {
+                format!(
+                    "could not inspect Windows acceptance-only plugin {}: {error}",
+                    path.display()
+                )
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(format!(
+                    "refusing non-file Windows acceptance cleanup target {}",
+                    path.display()
+                ));
+            }
+            fs::remove_file(path).map_err(|error| {
+                format!(
+                    "could not remove Windows acceptance-only plugin {}: {error}",
+                    path.display()
+                )
+            })?;
         }
-        let metadata = fs::symlink_metadata(path).map_err(|error| {
-            format!(
-                "could not inspect Windows acceptance-only plugin {}: {error}",
-                path.display()
-            )
-        })?;
-        if !metadata.file_type().is_file() {
-            return Err(format!(
-                "refusing non-file Windows acceptance cleanup target {}",
-                path.display()
-            ));
+        if plugin_directory_created {
+            let directory = path.parent().ok_or_else(|| {
+                format!("acceptance plugin has no parent directory: {}", path.display())
+            })?;
+            guarded_clone.assert_write_target(directory)?;
+            fs::remove_dir(directory).map_err(|error| {
+                format!(
+                    "could not remove test-created Windows generic plugin directory {}: {error}",
+                    directory.display()
+                )
+            })?;
         }
-        fs::remove_file(path).map_err(|error| {
-            format!(
-                "could not remove Windows acceptance-only plugin {}: {error}",
-                path.display()
-            )
-        })
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src-tauri/tests/support/windows_live_orchestration.inc.rs
+++ b/src-tauri/tests/support/windows_live_orchestration.inc.rs
@@ -470,7 +470,8 @@
         repo: &Path,
         layout: &InstallLayout,
         guarded_clone: &GuardedTempRoot,
-    ) -> Result<(PathBuf, bool), String> {
+        plugin_directory_created: &mut bool,
+    ) -> Result<PathBuf, String> {
         let source = repo.join(
             "build/windows-injector/acceptance/generic/cavalryi18n_acceptance.dll",
         );
@@ -482,7 +483,7 @@
         }
         let plugin_directory = layout.root.join("generic");
         guarded_clone.assert_write_target(&plugin_directory)?;
-        let plugin_directory_created = match fs::create_dir(&plugin_directory) {
+        *plugin_directory_created = match fs::create_dir(&plugin_directory) {
             Ok(()) => true,
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 if !plugin_directory.is_dir() {
@@ -572,7 +573,7 @@
                 destination.display()
             ));
         }
-        Ok((destination, plugin_directory_created))
+        Ok(destination)
     }
 
     fn remove_acceptance_plugin(

--- a/src-tauri/tests/support/windows_live_tests.inc.rs
+++ b/src-tauri/tests/support/windows_live_tests.inc.rs
@@ -1,7 +1,7 @@
 /**
  * [INPUT]: 依赖 live support 分片、clone guard、PowerShell/helper 源码与显式 disposable clone/evidence 环境；release 模式还依赖最终 NSIS/provenance 与双 DLL 字节
- * [OUTPUT]: 在父测试模块内提供静态安全合同和 full-surface/Onboarding/Adjacent 三个 ignored 人工复核门；FullSurfaces 只在 TEMP-owned profile 与关键 clone 资源已证明完整后启动；release machine record 只接受 live runner 源 DLL 与最终 shipped DLL 完全一致
- * [POS]: src-tauri/tests/support 的门入口分片；任何 live clone 资源不完整、FullSurfaces 未绑定 TEMP-owned profile 或使用不同于最终 NSIS 的 runtime DLL 都先于人工截图结论硬失败
+ * [OUTPUT]: 在父测试模块内提供静态安全合同和 full-surface/Onboarding/Adjacent 三个 ignored 人工复核门；FullSurfaces 只在 TEMP-owned profile 与关键 clone 资源已证明完整后启动；Onboarding/Adjacent 记录验收插件目录是否由本次创建并交给清理事务恢复拓扑；release machine record 只接受 live runner 源 DLL 与最终 shipped DLL 完全一致
+ * [POS]: src-tauri/tests/support 的门入口分片；任何 live clone 资源不完整、FullSurfaces 未绑定 TEMP-owned profile、验收插件或其测试创建目录清理失败，或使用不同于最终 NSIS 的 runtime DLL，都先于人工截图结论硬失败
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
     fn describe_panic(payload: &(dyn std::any::Any + Send)) -> String {
@@ -656,11 +656,14 @@
         } else {
             None
         };
+        let mut acceptance_plugin_directory_created = false;
 
         let mut outstanding_processes = BTreeSet::new();
         let exercise = catch_unwind(AssertUnwindSafe(|| {
             if acceptance_plugin.is_some() {
-                let installed = install_acceptance_plugin(&repo, &layout, &guarded_clone)?;
+                let (installed, created_directory) =
+                    install_acceptance_plugin(&repo, &layout, &guarded_clone)?;
+                acceptance_plugin_directory_created = created_directory;
                 if acceptance_plugin.as_deref() != Some(installed.as_path()) {
                     return Err(format!(
                         "acceptance plugin destination mismatch: {}",
@@ -714,7 +717,11 @@
             failures.push(format!("cleanup error: {error}"));
         }
         if let Some(path) = acceptance_plugin.as_deref() {
-            if let Err(error) = remove_acceptance_plugin(&guarded_clone, path) {
+            if let Err(error) = remove_acceptance_plugin(
+                &guarded_clone,
+                path,
+                acceptance_plugin_directory_created,
+            ) {
                 failures.push(format!("acceptance plugin cleanup error: {error}"));
             }
         }

--- a/src-tauri/tests/support/windows_live_tests.inc.rs
+++ b/src-tauri/tests/support/windows_live_tests.inc.rs
@@ -661,9 +661,12 @@
         let mut outstanding_processes = BTreeSet::new();
         let exercise = catch_unwind(AssertUnwindSafe(|| {
             if acceptance_plugin.is_some() {
-                let (installed, created_directory) =
-                    install_acceptance_plugin(&repo, &layout, &guarded_clone)?;
-                acceptance_plugin_directory_created = created_directory;
+                let installed = install_acceptance_plugin(
+                    &repo,
+                    &layout,
+                    &guarded_clone,
+                    &mut acceptance_plugin_directory_created,
+                )?;
                 if acceptance_plugin.as_deref() != Some(installed.as_path()) {
                     return Err(format!(
                         "acceptance plugin destination mismatch: {}",


### PR DESCRIPTION
## Root cause

English cleanup leaves an otherwise clean Cavalry clone without a root generic directory. The live Onboarding/Adjacent runner attempted to create its acceptance-only DLL temporary file below that missing parent, so repeat acceptance failed before Cavalry launched.

## Fix

- Create the single generic plugin directory inside the already guarded disposable clone.
- Re-check the directory through the sentinel/reparse guard before publishing the DLL atomically.
- Reject an existing non-directory path.
- Update the L3 contract and support L2 map.

## Evidence

- Red: real Onboarding run failed at temporary acceptance plugin creation with os error 3 while generic was absent.
- Green behavior: the same missing-directory clone completed 3 languages x 5 Onboarding captures, English restore, and zero-process cleanup; machine record then correctly refused only because the source worktree was dirty.
- cargo test --test manual_windows_live_smoke: 10 passed, 3 ignored.
- npm run test:acceptance:windows:contract: 4 passed.
- cargo fmt --all -- --check and git diff --check passed.

Refs #16