### PR TITLE
chore(release): 1.0.1 / cavalry-2.7.2-p7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-09-08
+
 ### Fixed
-- Detach Fast Quick Add search adapters when their view is destroyed so a surviving native filter cannot retain a stale query.
-- Keep shared Add Layer search compatible with Windows Qt builds that disable keyword macros.
-- Preserve native Classic Add Layer ordering by excluding search tokens from sorting rather than relying on platform-specific collation weights.
-- Preserve original font-family and font-style values in editable selectors instead of replacing them with UI translations.
-- Preserve Add Layer search input and restore English/current-language lookup while keeping translated result titles separate from layer identities.
+- Preserve font-family and font-style selections instead of replacing their values with UI translations.
+- Restore English and current-language search in both Add Layer interfaces without rewriting the search input or changing native result ordering.
+- Translate Fast Quick Add result titles and category labels while preserving the original layer identities used for creation.
+- Prevent stale queries from surviving after Fast Quick Add is closed.
 
 ## [1.0.0] - 2026-09-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavalry-i18n",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavalry-i18n",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@tauri-apps/api": "2.10.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cavalry-i18n",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tauri desktop language patcher for Cavalry-i18n",
   "scripts": {
     "check:ui-coverage": "node tools/check_runtime_ui_coverage.js --inventory \"$SESSION_DIR/runtime/${LANGUAGE:-zh-Hans}-merged-inventory.json\" --threshold 100 --extraction-inventory \"$SESSION_DIR/extraction-inventory.json\"",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "cavalry-i18n-tauri"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64 0.22.1",
  "cc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cavalry-i18n-tauri"
-version = "1.0.0"
+version = "1.0.1"
 description = "Tauri shell for Cavalry-i18n"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Cavalry Language Switcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.daftai.cavalry-i18n",
   "build": {
     "frontendDist": "../renderer"

--- a/tools/dependency_vulnerability_gate.json
+++ b/tools/dependency_vulnerability_gate.json
@@ -5,7 +5,7 @@
     "nodeVersion": "24.20.0",
     "npmVersion": "11.19.0",
     "registry": "https://registry.npmjs.org",
-    "packageLockSha256": "20c3d23092c6dd4cb382d99e7696c4e597f8231108cc5fec38f741c7b3fd9fc8",
+    "packageLockSha256": "2971083dd0bca56736e7751b5a28a50fbd3965b28e9ddcd92e1d23f886d70575",
     "dependencyCounts": {
       "prod": 2,
       "dev": 13,


### PR DESCRIPTION
## 发布范围
为已合并的字体值、双语搜索、Fast 标题与类别标签修复准备补丁发布。内部版本 1.0.1，公开 tag cavalry-2.7.2-p7；没有新的运行时改动，不重复已完成的 scoped 实机矩阵。

## 变更
- 从 CHANGELOG 同步 npm/Cargo/Tauri 和两个 lockfile 的应用版本，收拢用户可见修复说明。
- package-lock 只变应用版本，依赖闭包逐项不变；同步锁文件摘要 pin，并实际运行 npm audit 确认零漏洞，不放宽门禁。

## 检查
- check:version / check:release：PASS
- test:contracts：278/278
- Actions pin、source artifact repository/workflow gates：PASS
- 发布说明提取及标点门：PASS
- p7 元数据已核对，tag 尚未创建。

## 后续
当前 head CI 与 review 满足后正常合并，再按 LOCAL_BUILD_SOP.md 从 main 推送 p7 tag。跟进 tag 全量构建及七项公开资产回读，不将源码检查冒充发布资产验证。用户已授权本轮 p7 发布。