### PR TITLE
docs: 更新 p7 发布徽章

### DIFF
--- a/docs/badges/release.json
+++ b/docs/badges/release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "release",
-  "message": "cavalry-2.7.2-p6",
+  "message": "cavalry-2.7.2-p7",
   "color": "blue"
 }


### PR DESCRIPTION
p7 已公开发布；发布流水线已生成单文件徽章更新，但 GitHub Actions 无创建 PR 权限，现由维护者补开。仅同步 docs/badges/release.json，不改产品或 tag。发布地址：https://github.com/daftAI2026/Cavalry-i18n/releases/tag/cavalry-2.7.2-p7