### PR TITLE
fix(release): 中文更新说明与分类语义分离

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 [INPUT]: 依赖当前版本线、已验证代码/打包行为与公开发布协议
-[OUTPUT]: 对外提供按 SemVer 组织、中文在前英文在后的用户可见新增、变更与修复记录（旧版本保留历史原文）
+[OUTPUT]: 对外提供按 SemVer 组织的中文用户更新条目，英文分类保留机器语义（旧版本保留历史原文）
 [POS]: 根目录发布历史真相；Unreleased 只记录已落地且具备验证证据的行为
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
 -->
@@ -16,21 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2026-09-09
 
-### 中文
-
-#### 修复
+### Fixed
 - 升级语言切换器后，可以直接更新当前语言补丁，无需先切换其他语言或恢复英文。
 - 当前语言有可用更新时，在语言名称旁显示“可更新”徽章，点击“更新”即可重新应用。
 - 更新会完整应用当前语言包，并校验恢复数据、模型身份和受管运行时的归属，不依赖历史译文版本。
 - 旧版受管 macOS 安装也可以更新翻译运行时和启动器，同时保留原有英文恢复能力的边界。
-
-### English
-
-#### Fixed
-- Allow updating the current language patch after upgrading the Switcher, without switching to another language or restoring English first.
-- Show a localized update badge beside the current language when its patch can be reapplied.
-- Reapply the complete current language pack without requiring historical translation versions, while verifying recovery data, model identities and managed runtime ownership.
-- Update the owned translator and launcher on older managed macOS installations while preserving their existing English recovery boundary.
 
 ## [1.0.1] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 [INPUT]: 依赖当前版本线、已验证代码/打包行为与公开发布协议
-[OUTPUT]: 对外提供按 SemVer 组织的用户可见新增、变更与修复记录
+[OUTPUT]: 对外提供按 SemVer 组织、中文在前英文在后的用户可见新增、变更与修复记录（旧版本保留历史原文）
 [POS]: 根目录发布历史真相；Unreleased 只记录已落地且具备验证证据的行为
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
 -->
@@ -16,7 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2026-09-09
 
-### Fixed
+### 中文
+
+#### 修复
+- 升级语言切换器后，可以直接更新当前语言补丁，无需先切换其他语言或恢复英文。
+- 当前语言有可用更新时，在语言名称旁显示“可更新”徽章，点击“更新”即可重新应用。
+- 更新会完整应用当前语言包，并校验恢复数据、模型身份和受管运行时的归属，不依赖历史译文版本。
+- 旧版受管 macOS 安装也可以更新翻译运行时和启动器，同时保留原有英文恢复能力的边界。
+
+### English
+
+#### Fixed
 - Allow updating the current language patch after upgrading the Switcher, without switching to another language or restoring English first.
 - Show a localized update badge beside the current language when its patch can be reapplied.
 - Reapply the complete current language pack without requiring historical translation versions, while verifying recovery data, model identities and managed runtime ownership.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ output/ - 派生审计产物，保存截图、JSON surface 抓取与翻译草稿
 
 <config>
 AGENTS.md - 根级 Agent 行动地图，按 Kumo knowledge base 结构固化查找入口、约定、反模式、命令、流水线、工具链与安全边界
-CHANGELOG.md - 新版本中文在前/英文在后的 SemVer 发布历史与 Unreleased 用户可见变更真相源；tag 正文由 workflow 按版本抽取，不保留会漂移的根目录 release body 快照
+CHANGELOG.md - 新版本中文条目与英文分类语义分离的 SemVer 发布历史与 Unreleased 用户可见变更真相源；tag 正文由 workflow 按版本抽取，不保留会漂移的根目录 release body 快照
 LOCAL_BUILD_SOP.md - 唯一桌面打包与发布操作合同，区分本地验证、ad-hoc tag、Tauri updater 签名和未具备的平台身份，并固定 macOS DMG 文件名与挂载卷标的不同职责
 README.md - 英文主入口，四语发布徽章直接读取 GitHub 最新正式 Release tag，冻结头部/预览/支持/许可证节点，以用户任务为顺序压缩功能、安全、安装、运行与开发说明
 README.zh-Hans.md - 简体中文 README，与英文入口保持标题结构、用户事实、命令和导航同构

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ output/ - 派生审计产物，保存截图、JSON surface 抓取与翻译草稿
 
 <config>
 AGENTS.md - 根级 Agent 行动地图，按 Kumo knowledge base 结构固化查找入口、约定、反模式、命令、流水线、工具链与安全边界
-CHANGELOG.md - SemVer 发布历史与 Unreleased 用户可见变更真相源；tag 正文由 workflow 按版本抽取，不保留会漂移的根目录 release body 快照
+CHANGELOG.md - 新版本中文在前/英文在后的 SemVer 发布历史与 Unreleased 用户可见变更真相源；tag 正文由 workflow 按版本抽取，不保留会漂移的根目录 release body 快照
 LOCAL_BUILD_SOP.md - 唯一桌面打包与发布操作合同，区分本地验证、ad-hoc tag、Tauri updater 签名和未具备的平台身份，并固定 macOS DMG 文件名与挂载卷标的不同职责
 README.md - 英文主入口，四语发布徽章直接读取 GitHub 最新正式 Release tag，冻结头部/预览/支持/许可证节点，以用户任务为顺序压缩功能、安全、安装、运行与开发说明
 README.zh-Hans.md - 简体中文 README，与英文入口保持标题结构、用户事实、命令和导航同构

--- a/LOCAL_BUILD_SOP.md
+++ b/LOCAL_BUILD_SOP.md
@@ -1,6 +1,6 @@
 <!--
 [INPUT]: 依赖 Tauri 平台配置、renderer 静态资源装载方式、macOS Info.plist/InfoPlist.strings 资源、release.config、Qt injector/QPA 构建入口、共享 translation policy、编译期 Windows 资源 trust-anchor catalog、固定官方 CMake 4.4.3 archive 与 SHA-256、NSIS provenance/安装态守门、pinned toolchain、disposable live-clone 截图门与打包检查脚本
-[OUTPUT]: 对外提供 renderer 新鲜度受控的本地视觉验证、macOS ad-hoc 包、App Management 用途说明的 bundle readback、本地化资源路径合同、tag 级 Tauri updater 签名与明确未公证的发布合同、source artifact 完整性、中英双语版本说明、七项公开资产回读与 CI 内部 provenance、幂等 release、可追溯 Windows producer toolchain evidence、Windows disposable acceptance producer 与 Windows NSIS 构建/安装态边界说明（Developer ID/notarization 与 Authenticode 均另跟踪）
+[OUTPUT]: 对外提供 renderer 新鲜度受控的本地视觉验证、macOS ad-hoc 包、App Management 用途说明的 bundle readback、本地化资源路径合同、tag 级 Tauri updater 签名与明确未公证的发布合同、source artifact 完整性、中文发布说明与英文分类语义分离、七项公开资产回读与 CI 内部 provenance、幂等 release、可追溯 Windows producer toolchain evidence、Windows disposable acceptance producer 与 Windows NSIS 构建/安装态边界说明（Developer ID/notarization 与 Authenticode 均另跟踪）
 [POS]: 仓库唯一桌面打包与 release runbook 操作合同；区分本地 ad-hoc 验证、CI PR 编译门与带 updater/证据闭包的 ad-hoc tag 产物
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
 -->
@@ -78,28 +78,21 @@ git push origin "$TAG"
 4. 发布 job 生成两份 DMG、一份 Windows NSIS、两个 macOS updater archive、三平台签名输入与 `latest.json`，并在 CI 内生成 `CycloneDX.json`、`toolchain-evidence.json` 和 `release-asset-provenance.json`。公开 Release 只上传三项安装包、两个 macOS updater archive、`latest.json` 与 `SHA256SUMS` 共七项资产；独立 `.sig` 和构建证据仅在 CI 内验证。发布器先创建 private draft，上传后逐项下载并复算这七项公开字节；缺件、额外资产、摘要漂移或远端冲突都会停止，全部一致后才公开。
 5. **Apple Developer ID/notarization** 与 **Windows Authenticode** 均不在当前 SOP 的发布前提内；获得相应身份后再单独升级，不得预先写成已完成。macOS updater 仍由独立 Tauri Ed25519 签名验证，但它不创造 Apple 平台身份。
 
-6. Release 正文由 workflow 中的版本更新记录与固定用户指引组成。**版本更新说明必须中文在前、英文在后**，两段描述同一批实际改动；按本版情况选择新增/变更/修复，不强制填空分类，不用产品介绍代替更新条目。CHANGELOG 的版本区块采用下方模板，抽取器检查两个语言段及非空条目，GitHub 正文和未来 updater notes 共用该投影。已发布正文修订不替换历史 updater manifest 或安装包。固定部分保留 macOS 首次打开、Windows 首次安装、带版本链接的源码构建步骤、四语支持列表、权限/备份须知及简短英日说明；不要用维护者私有绝对路径替代通用 `<仓库路径>`。只修改已发布正文时使用 `gh release edit --notes-file`，不重打 tag、不替换资产，并回读正文及资产摘要。
+6. Release 正文由 workflow 中的版本更新记录与固定用户指引组成。**从 p8 开始，版本更新说明只显示中文**，不额外显示“中文 / English”语言标题。CHANGELOG 使用 Added/Changed/Fixed 等稳定英文分类键，条目写本版实际中文变化；抽取器只把分类标题映射为新增/变更/修复，不自动翻译正文，不用产品介绍代替更新条目。未来 GitHub Release 与 updater notes 共用该中文投影。已发布正文修订不替换历史 updater manifest 或安装包。固定部分保留 macOS 首次打开、Windows 首次安装、带版本链接的源码构建步骤、四语支持列表、权限/备份须知及简短英日说明；不要用维护者私有绝对路径替代通用 `<仓库路径>`。只修改已发布正文时使用 `gh release edit --notes-file`，不重打 tag、不替换资产，并回读正文及资产摘要。
 7. 七项资产完成回读且 Release 公开后，`tools/post_release_reactions.js <tag> <owner/repo>` 添加并分页回读 👍、😄、🎉、❤️、🚀、👀 六种 reactions。沿用 Incodex 的六种反馈，GitHub 按账号去重；CI 使用现有 job token，失败作为非阻断提示，不重新发布资产。可用同一命令为已公开版本补做，但拒绝 draft/prerelease。
 
 ### 3.2 版本更新说明模板
 
-在对应 SemVer 的 CHANGELOG 区块填写真实条目，中文与英文逐项表达一致；保留历史版本原文，不为补正文而重发已有二进制。
+在对应 SemVer 的 CHANGELOG 区块填写实际中文条目。英文分类键只保存结构语义，发布抽取器将其转换为中文标题；不生成双语副本或“中文 / English”标题。历史版本原文不改，不为补正文重发二进制。
 
 ```markdown
 ## [x.y.z] - YYYY-MM-DD
 
-### 中文
-
-#### 修复
+### Fixed
 - 本版本实际解决的问题及用户可感知的结果。
-
-### English
-
-#### Fixed
-- The same version-specific fix and its user-visible result.
 ```
 
-有新增时使用 `#### 新增` / `#### Added`，有行为变更时使用 `#### 变更` / `#### Changed`；不需要的分类不写。门禁只检查结构和非空条目，翻译是否准确、两语事实是否一致仍需 review。
+分类映射为：Added → 新增、Changed → 变更、Deprecated → 弃用、Removed → 移除、Fixed → 修复、Security → 安全。只写本版需要的分类，不留空标题。门禁检查唯一受支持分类、非空条目及中文内容存在；文案准确性仍由 review 确认。
 
 ## 4. macOS 标准打包流程
 

--- a/LOCAL_BUILD_SOP.md
+++ b/LOCAL_BUILD_SOP.md
@@ -92,7 +92,7 @@ git push origin "$TAG"
 - 本版本实际解决的问题及用户可感知的结果。
 ```
 
-分类映射为：Added → 新增、Changed → 变更、Deprecated → 弃用、Removed → 移除、Fixed → 修复、Security → 安全。只写本版需要的分类，不留空标题。门禁检查唯一受支持分类、非空条目及中文内容存在；文案准确性仍由 review 确认。
+分类映射为：Added → 新增、Changed → 变更、Deprecated → 弃用、Removed → 移除、Fixed → 修复、Security → 安全。只写本版需要的分类，不留空标题。每个条目使用单行 `- 中文说明`，分类内只允许条目及空行，不放代码围栏、HTML 注释或独立说明段。门禁检查唯一受支持分类、非空条目且逐条包含中文；文案准确性仍由 review 确认。
 
 ## 4. macOS 标准打包流程
 

--- a/LOCAL_BUILD_SOP.md
+++ b/LOCAL_BUILD_SOP.md
@@ -1,6 +1,6 @@
 <!--
 [INPUT]: 依赖 Tauri 平台配置、renderer 静态资源装载方式、macOS Info.plist/InfoPlist.strings 资源、release.config、Qt injector/QPA 构建入口、共享 translation policy、编译期 Windows 资源 trust-anchor catalog、固定官方 CMake 4.4.3 archive 与 SHA-256、NSIS provenance/安装态守门、pinned toolchain、disposable live-clone 截图门与打包检查脚本
-[OUTPUT]: 对外提供 renderer 新鲜度受控的本地视觉验证、macOS ad-hoc 包、App Management 用途说明的 bundle readback、本地化资源路径合同、tag 级 Tauri updater 签名与明确未公证的发布合同、source artifact 完整性、七项公开资产回读与 CI 内部 provenance、幂等 release、可追溯 Windows producer toolchain evidence、Windows disposable acceptance producer 与 Windows NSIS 构建/安装态边界说明（Developer ID/notarization 与 Authenticode 均另跟踪）
+[OUTPUT]: 对外提供 renderer 新鲜度受控的本地视觉验证、macOS ad-hoc 包、App Management 用途说明的 bundle readback、本地化资源路径合同、tag 级 Tauri updater 签名与明确未公证的发布合同、source artifact 完整性、中英双语版本说明、七项公开资产回读与 CI 内部 provenance、幂等 release、可追溯 Windows producer toolchain evidence、Windows disposable acceptance producer 与 Windows NSIS 构建/安装态边界说明（Developer ID/notarization 与 Authenticode 均另跟踪）
 [POS]: 仓库唯一桌面打包与 release runbook 操作合同；区分本地 ad-hoc 验证、CI PR 编译门与带 updater/证据闭包的 ad-hoc tag 产物
 [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
 -->
@@ -78,8 +78,28 @@ git push origin "$TAG"
 4. 发布 job 生成两份 DMG、一份 Windows NSIS、两个 macOS updater archive、三平台签名输入与 `latest.json`，并在 CI 内生成 `CycloneDX.json`、`toolchain-evidence.json` 和 `release-asset-provenance.json`。公开 Release 只上传三项安装包、两个 macOS updater archive、`latest.json` 与 `SHA256SUMS` 共七项资产；独立 `.sig` 和构建证据仅在 CI 内验证。发布器先创建 private draft，上传后逐项下载并复算这七项公开字节；缺件、额外资产、摘要漂移或远端冲突都会停止，全部一致后才公开。
 5. **Apple Developer ID/notarization** 与 **Windows Authenticode** 均不在当前 SOP 的发布前提内；获得相应身份后再单独升级，不得预先写成已完成。macOS updater 仍由独立 Tauri Ed25519 签名验证，但它不创造 Apple 平台身份。
 
-6. Release 正文由 workflow 中的版本更新记录与固定用户指引组成。固定部分保留 macOS 首次打开、Windows 首次安装、带版本链接的源码构建步骤、四语支持列表、权限/备份须知及简短英日说明；不要用维护者私有绝对路径替代通用 `<仓库路径>`。只修改已发布正文时使用 `gh release edit --notes-file`，不重打 tag、不替换资产，并回读正文及资产摘要。
+6. Release 正文由 workflow 中的版本更新记录与固定用户指引组成。**版本更新说明必须中文在前、英文在后**，两段描述同一批实际改动；按本版情况选择新增/变更/修复，不强制填空分类，不用产品介绍代替更新条目。CHANGELOG 的版本区块采用下方模板，抽取器检查两个语言段及非空条目，GitHub 正文和未来 updater notes 共用该投影。已发布正文修订不替换历史 updater manifest 或安装包。固定部分保留 macOS 首次打开、Windows 首次安装、带版本链接的源码构建步骤、四语支持列表、权限/备份须知及简短英日说明；不要用维护者私有绝对路径替代通用 `<仓库路径>`。只修改已发布正文时使用 `gh release edit --notes-file`，不重打 tag、不替换资产，并回读正文及资产摘要。
 7. 七项资产完成回读且 Release 公开后，`tools/post_release_reactions.js <tag> <owner/repo>` 添加并分页回读 👍、😄、🎉、❤️、🚀、👀 六种 reactions。沿用 Incodex 的六种反馈，GitHub 按账号去重；CI 使用现有 job token，失败作为非阻断提示，不重新发布资产。可用同一命令为已公开版本补做，但拒绝 draft/prerelease。
+
+### 3.2 版本更新说明模板
+
+在对应 SemVer 的 CHANGELOG 区块填写真实条目，中文与英文逐项表达一致；保留历史版本原文，不为补正文而重发已有二进制。
+
+```markdown
+## [x.y.z] - YYYY-MM-DD
+
+### 中文
+
+#### 修复
+- 本版本实际解决的问题及用户可感知的结果。
+
+### English
+
+#### Fixed
+- The same version-specific fix and its user-visible result.
+```
+
+有新增时使用 `#### 新增` / `#### Added`，有行为变更时使用 `#### 变更` / `#### Changed`；不需要的分类不写。门禁只检查结构和非空条目，翻译是否准确、两语事实是否一致仍需 review。
 
 ## 4. macOS 标准打包流程
 

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -57,7 +57,7 @@ create_sbom.js / verify_release_provenance.js: 从 npm/Cargo lockfiles 生成确
 create_source_artifact.js / verify_source_artifact.js / source_artifact_manifest.json + schemas/: 用 mode-preserving tar 输出 repo 外 source artifact；verifier 独立生成同 commit 的 `git archive`，逐 entry 拒绝 link/special/traversal/duplicate/secret 并精确比对路径、bytes、type 与 mode，marker 不能替代 tree 校验。
 verify_ci_action_pins.js + ci_action_pins.json: 以 strict unique-key YAML AST 枚举 job/step 全部 `uses`（含 unnamed、`if`-first、flow mapping 与 quoted key），执行 GitHub Actions 全量 40 位 SHA allowlist、Node/Python/aqt/Rust 精确 pin，并拒绝 cargo-audit 绕过 channel qualifier 触发项目组件调和。
 record_toolchain_evidence.js / create_toolchain_evidence_bundle.js: 前者在 source-contract/macOS 真实 producer 上 fail-closed 捕获无 secret 的版本与 runner 证据；后者要求 source-contracts、macOS aarch64/x64 三 scope 与 release commit/target 精确一致，聚合为由公开 provenance 绑定的 `toolchain-evidence.json`；Windows producer evidence 由 `record_windows_toolchain_evidence.js` 单独上传，待 #16 纳入 release 聚合。
-extract_release_changelog.js: 中文在前/英文在后且两段均有更新条目的 Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
+extract_release_changelog.js: 保留英文分类语义并投影中文标题、要求中文更新条目的 Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
 check_runtime_ui_coverage.js: runtime UI 覆盖率守门脚本，读取真实菜单 inventory 并按阈值阻塞未翻译文本。
 check_full_ui_coverage.js: 单语言全 UI 覆盖检查，组合 runtime、compiled、JSON-backed 校验，并通过共享 Python 命令边界启动验证器。
 check_full_ui_matrix.js: 多语言矩阵覆盖检查，写出稳定 runlog 便于连续追踪。

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -57,7 +57,7 @@ create_sbom.js / verify_release_provenance.js: 从 npm/Cargo lockfiles 生成确
 create_source_artifact.js / verify_source_artifact.js / source_artifact_manifest.json + schemas/: 用 mode-preserving tar 输出 repo 外 source artifact；verifier 独立生成同 commit 的 `git archive`，逐 entry 拒绝 link/special/traversal/duplicate/secret 并精确比对路径、bytes、type 与 mode，marker 不能替代 tree 校验。
 verify_ci_action_pins.js + ci_action_pins.json: 以 strict unique-key YAML AST 枚举 job/step 全部 `uses`（含 unnamed、`if`-first、flow mapping 与 quoted key），执行 GitHub Actions 全量 40 位 SHA allowlist、Node/Python/aqt/Rust 精确 pin，并拒绝 cargo-audit 绕过 channel qualifier 触发项目组件调和。
 record_toolchain_evidence.js / create_toolchain_evidence_bundle.js: 前者在 source-contract/macOS 真实 producer 上 fail-closed 捕获无 secret 的版本与 runner 证据；后者要求 source-contracts、macOS aarch64/x64 三 scope 与 release commit/target 精确一致，聚合为由公开 provenance 绑定的 `toolchain-evidence.json`；Windows producer evidence 由 `record_windows_toolchain_evidence.js` 单独上传，待 #16 纳入 release 聚合。
-extract_release_changelog.js: Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
+extract_release_changelog.js: 中文在前/英文在后且两段均有更新条目的 Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
 check_runtime_ui_coverage.js: runtime UI 覆盖率守门脚本，读取真实菜单 inventory 并按阈值阻塞未翻译文本。
 check_full_ui_coverage.js: 单语言全 UI 覆盖检查，组合 runtime、compiled、JSON-backed 校验，并通过共享 Python 命令边界启动验证器。
 check_full_ui_matrix.js: 多语言矩阵覆盖检查，写出稳定 runlog 便于连续追踪。

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -57,7 +57,7 @@ create_sbom.js / verify_release_provenance.js: 从 npm/Cargo lockfiles 生成确
 create_source_artifact.js / verify_source_artifact.js / source_artifact_manifest.json + schemas/: 用 mode-preserving tar 输出 repo 外 source artifact；verifier 独立生成同 commit 的 `git archive`，逐 entry 拒绝 link/special/traversal/duplicate/secret 并精确比对路径、bytes、type 与 mode，marker 不能替代 tree 校验。
 verify_ci_action_pins.js + ci_action_pins.json: 以 strict unique-key YAML AST 枚举 job/step 全部 `uses`（含 unnamed、`if`-first、flow mapping 与 quoted key），执行 GitHub Actions 全量 40 位 SHA allowlist、Node/Python/aqt/Rust 精确 pin，并拒绝 cargo-audit 绕过 channel qualifier 触发项目组件调和。
 record_toolchain_evidence.js / create_toolchain_evidence_bundle.js: 前者在 source-contract/macOS 真实 producer 上 fail-closed 捕获无 secret 的版本与 runner 证据；后者要求 source-contracts、macOS aarch64/x64 三 scope 与 release commit/target 精确一致，聚合为由公开 provenance 绑定的 `toolchain-evidence.json`；Windows producer evidence 由 `record_windows_toolchain_evidence.js` 单独上传，待 #16 纳入 release 聚合。
-extract_release_changelog.js: 保留英文分类语义并投影中文标题、要求中文更新条目的 Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
+extract_release_changelog.js: 保留英文分类语义并投影中文标题、要求逐条中文且拒绝伪列表的 Release notes 内容守门器，按内部 SemVer 从 `CHANGELOG.md` 精确抽取单个已发布日期区块；缺失、重复、未标日期或空正文时失败关闭，防止固定产品模板吞掉版本更新。
 check_runtime_ui_coverage.js: runtime UI 覆盖率守门脚本，读取真实菜单 inventory 并按阈值阻塞未翻译文本。
 check_full_ui_coverage.js: 单语言全 UI 覆盖检查，组合 runtime、compiled、JSON-backed 校验，并通过共享 Python 命令边界启动验证器。
 check_full_ui_matrix.js: 多语言矩阵覆盖检查，写出稳定 runlog 便于连续追踪。

--- a/tools/check_tauri_build_sop.js
+++ b/tools/check_tauri_build_sop.js
@@ -1378,6 +1378,10 @@ test('release changelog extractor selects one exact released SemVer section and 
 
   for (const invalid of [
     '### Fixed\n- English only.',
+    '### Fixed\n- 中文修复。\n- English-only note.',
+    '### Fixed\n```text\n- 中文示例。\n```',
+    '### Fixed\n<!--\n- 中文占位。\n-->',
+
     '### 中文\n- 只有中文。',
     '### Fixed',
     '### Fixed\n- 中文更新。\n### Fixed\n- 重复分类。',

--- a/tools/check_tauri_build_sop.js
+++ b/tools/check_tauri_build_sop.js
@@ -1391,6 +1391,16 @@ test('release changelog extractor selects one exact released SemVer section and 
     assert.equal(fs.existsSync(outputPath), false);
   }
 
+  for (const [category, label] of [
+    ['Added', '新增'], ['Changed', '变更'], ['Deprecated', '弃用'],
+    ['Removed', '移除'], ['Fixed', '修复'], ['Security', '安全'],
+  ]) {
+    fs.writeFileSync(changelogPath, '## [9.8.7] - 2026-07-14\n\n### ' + category + '\n- 实际更新。');
+    const projected = runExtractor('9.8.7');
+    assert.equal(projected.status, 0, projected.stderr);
+    assert.equal(fs.readFileSync(outputPath, 'utf8'), '### ' + label + '\n- 实际更新。\n');
+  }
+
   const missing = runExtractor('9.8.5');
   assert.notEqual(missing.status, 0, missing.stdout);
   assert.match(missing.stderr, /9\.8\.5[\s\S]*not found/i);

--- a/tools/check_tauri_build_sop.js
+++ b/tools/check_tauri_build_sop.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 依赖 package/CHANGELOG、跨平台工具、CI 变更分类器、test_temp_dir.js、DMG 卷标身份解析器、人工安装/updater 发布元数据、共享 Windows NSIS provenance schema/四策略输入合同/Quick Add context/display 与描述生成闭包/生命周期/live-clone、C++ text-path 源表顺序、PowerShell 双宿主/编码/Onboarding/Adjacent exact-HWND 边界、Tauri 配置与 macOS Info.plist 本地化资源、SOP/README/workflow、发布 provenance schema、Actions full-SHA pins、source artifact manifest 与原生产物忽略策略
- * [OUTPUT]: 对外提供 Tauri-only 发布协议、四语 README 用户路径合同、按文档/合同/依赖/平台风险选择且未知路径 fail-closed 的 CI 调度合同、renderer 视觉验收新进程合同、人工安装/updater 资产命名、macOS DMG `产品 + SemVer + 架构` 卷标、显式 renderer 文档入口、SOP/配置同构窗口合同、`main`/`about` capability 边界、macOS App Management 用途说明及最终 app bundle readback 合同、tag 级 macOS ad-hoc 与独立 updater 签名边界、中文在前英文在后的版本更新说明、七项公开资产 readback 与 CI 内部 provenance、source 完整性、Actions/toolchain pin、幂等 release、直接读取最新正式 Release 的四语徽章、平台原生构建隔离、Windows x64 provenance producer-consumer 同构与 PR 级 clean-macOS link gate
+ * [OUTPUT]: 对外提供 Tauri-only 发布协议、四语 README 用户路径合同、按文档/合同/依赖/平台风险选择且未知路径 fail-closed 的 CI 调度合同、renderer 视觉验收新进程合同、人工安装/updater 资产命名、macOS DMG `产品 + SemVer + 架构` 卷标、显式 renderer 文档入口、SOP/配置同构窗口合同、`main`/`about` capability 边界、macOS App Management 用途说明及最终 app bundle readback 合同、tag 级 macOS ad-hoc 与独立 updater 签名边界、保留英文分类语义、发布只显示中文的版本更新说明、七项公开资产 readback 与 CI 内部 provenance、source 完整性、Actions/toolchain pin、幂等 release、直接读取最新正式 Release 的四语徽章、平台原生构建隔离、Windows x64 provenance producer-consumer 同构与 PR 级 clean-macOS link gate
  * [POS]: tools 的 Phase 6 打包守门，连接发布协议、构建前 tag ancestry、平台 Runner 原生构建、Windows NSIS 安装态与 npm/Tauri 配置
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -1354,17 +1354,11 @@ test('release changelog extractor selects one exact released SemVer section and 
       '',
       '## [9.8.7] - 2026-07-14',
       '',
-      '### 中文',
-      '#### 新增',
+      '### Added',
       '- 本次新增功能。',
-      '#### 修复',
-      '- 本次修复问题。',
-      '### English',
-      '#### Added',
-      '- Exact release note.',
       '',
-      '#### Fixed',
-      '- Exact release fix.',
+      '### Fixed',
+      '- 本次修复问题。',
       '',
       '## [9.8.6] - 2026-07-13',
       '',
@@ -1378,23 +1372,22 @@ test('release changelog extractor selects one exact released SemVer section and 
   assert.equal(valid.status, 0, valid.stderr || valid.stdout);
   assert.equal(
     fs.readFileSync(outputPath, 'utf8'),
-    '### 中文\n#### 新增\n- 本次新增功能。\n#### 修复\n- 本次修复问题。\n### English\n#### Added\n- Exact release note.\n\n#### Fixed\n- Exact release fix.\n'
+    '### 新增\n- 本次新增功能。\n\n### 修复\n- 本次修复问题。\n'
   );
   assert.doesNotMatch(fs.readFileSync(outputPath, 'utf8'), /Not ready|Older release/);
 
   for (const invalid of [
     '### Fixed\n- English only.',
     '### 中文\n- 只有中文。',
-    '### English\n- English first.\n### 中文\n- 中文在后。',
-    '### 中文\n### English\n- Missing Chinese changes.',
-    '### 中文\n- 中文更新。\n### English',
-    '### 中文\n- 中文更新。\n### English\n- Changes.\n### English\n- Duplicate.',
+    '### Fixed',
+    '### Fixed\n- 中文更新。\n### Fixed\n- 重复分类。',
+    '### Unknown\n- 未知分类。',
   ]) {
     fs.writeFileSync(changelogPath, '## [9.8.7] - 2026-07-14\n\n' + invalid);
     fs.writeFileSync(outputPath, 'stale output');
     const rejected = runExtractor('9.8.7');
     assert.notEqual(rejected.status, 0, invalid);
-    assert.match(rejected.stderr, /bilingual/i);
+    assert.match(rejected.stderr, /Chinese|category/i);
     assert.equal(fs.existsSync(outputPath), false);
   }
 

--- a/tools/check_tauri_build_sop.js
+++ b/tools/check_tauri_build_sop.js
@@ -1420,6 +1420,12 @@ test('release changelog extractor selects one exact released SemVer section and 
   const empty = runExtractor('9.8.7');
   assert.notEqual(empty.status, 0, empty.stdout);
   assert.match(empty.stderr, /9\.8\.7[\s\S]*empty/i);
+
+  fs.writeFileSync(changelogPath, readText('CHANGELOG.md'));
+  const currentVersion = JSON.parse(readText('package.json')).version;
+  const current = runExtractor(currentVersion);
+  assert.equal(current.status, 0, 'current release notes: ' + current.stderr);
+
 });
 
 test('README release badges use the latest stable GitHub Release directly', () => {

--- a/tools/check_tauri_build_sop.js
+++ b/tools/check_tauri_build_sop.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 依赖 package/CHANGELOG、跨平台工具、CI 变更分类器、test_temp_dir.js、DMG 卷标身份解析器、人工安装/updater 发布元数据、共享 Windows NSIS provenance schema/四策略输入合同/Quick Add context/display 与描述生成闭包/生命周期/live-clone、C++ text-path 源表顺序、PowerShell 双宿主/编码/Onboarding/Adjacent exact-HWND 边界、Tauri 配置与 macOS Info.plist 本地化资源、SOP/README/workflow、发布 provenance schema、Actions full-SHA pins、source artifact manifest 与原生产物忽略策略
- * [OUTPUT]: 对外提供 Tauri-only 发布协议、四语 README 用户路径合同、按文档/合同/依赖/平台风险选择且未知路径 fail-closed 的 CI 调度合同、renderer 视觉验收新进程合同、人工安装/updater 资产命名、macOS DMG `产品 + SemVer + 架构` 卷标、显式 renderer 文档入口、SOP/配置同构窗口合同、`main`/`about` capability 边界、macOS App Management 用途说明及最终 app bundle readback 合同、tag 级 macOS ad-hoc 与独立 updater 签名边界、七项公开资产 readback 与 CI 内部 provenance、source 完整性、Actions/toolchain pin、幂等 release、直接读取最新正式 Release 的四语徽章、平台原生构建隔离、Windows x64 provenance producer-consumer 同构与 PR 级 clean-macOS link gate
+ * [OUTPUT]: 对外提供 Tauri-only 发布协议、四语 README 用户路径合同、按文档/合同/依赖/平台风险选择且未知路径 fail-closed 的 CI 调度合同、renderer 视觉验收新进程合同、人工安装/updater 资产命名、macOS DMG `产品 + SemVer + 架构` 卷标、显式 renderer 文档入口、SOP/配置同构窗口合同、`main`/`about` capability 边界、macOS App Management 用途说明及最终 app bundle readback 合同、tag 级 macOS ad-hoc 与独立 updater 签名边界、中文在前英文在后的版本更新说明、七项公开资产 readback 与 CI 内部 provenance、source 完整性、Actions/toolchain pin、幂等 release、直接读取最新正式 Release 的四语徽章、平台原生构建隔离、Windows x64 provenance producer-consumer 同构与 PR 级 clean-macOS link gate
  * [POS]: tools 的 Phase 6 打包守门，连接发布协议、构建前 tag ancestry、平台 Runner 原生构建、Windows NSIS 安装态与 npm/Tauri 配置
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -1354,10 +1354,16 @@ test('release changelog extractor selects one exact released SemVer section and 
       '',
       '## [9.8.7] - 2026-07-14',
       '',
-      '### Added',
+      '### 中文',
+      '#### 新增',
+      '- 本次新增功能。',
+      '#### 修复',
+      '- 本次修复问题。',
+      '### English',
+      '#### Added',
       '- Exact release note.',
       '',
-      '### Fixed',
+      '#### Fixed',
       '- Exact release fix.',
       '',
       '## [9.8.6] - 2026-07-13',
@@ -1372,9 +1378,25 @@ test('release changelog extractor selects one exact released SemVer section and 
   assert.equal(valid.status, 0, valid.stderr || valid.stdout);
   assert.equal(
     fs.readFileSync(outputPath, 'utf8'),
-    '### Added\n- Exact release note.\n\n### Fixed\n- Exact release fix.\n'
+    '### 中文\n#### 新增\n- 本次新增功能。\n#### 修复\n- 本次修复问题。\n### English\n#### Added\n- Exact release note.\n\n#### Fixed\n- Exact release fix.\n'
   );
   assert.doesNotMatch(fs.readFileSync(outputPath, 'utf8'), /Not ready|Older release/);
+
+  for (const invalid of [
+    '### Fixed\n- English only.',
+    '### 中文\n- 只有中文。',
+    '### English\n- English first.\n### 中文\n- 中文在后。',
+    '### 中文\n### English\n- Missing Chinese changes.',
+    '### 中文\n- 中文更新。\n### English',
+    '### 中文\n- 中文更新。\n### English\n- Changes.\n### English\n- Duplicate.',
+  ]) {
+    fs.writeFileSync(changelogPath, '## [9.8.7] - 2026-07-14\n\n' + invalid);
+    fs.writeFileSync(outputPath, 'stale output');
+    const rejected = runExtractor('9.8.7');
+    assert.notEqual(rejected.status, 0, invalid);
+    assert.match(rejected.stderr, /bilingual/i);
+    assert.equal(fs.existsSync(outputPath), false);
+  }
 
   const missing = runExtractor('9.8.5');
   assert.notEqual(missing.status, 0, missing.stdout);

--- a/tools/extract_release_changelog.js
+++ b/tools/extract_release_changelog.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 依赖发布流程传入的内部 SemVer、CHANGELOG.md 与目标输出路径
- * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期、正文为空或缺少中文在前/英文在后的更新条目时失败关闭
+ * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期、正文为空或缺少中文更新条目时失败关闭；保留 Added/Fixed 等源码分类语义，仅在发布投影为中文标题
  * [POS]: tools 的 Release notes 内容边界，将内部版本真相源投影为 GitHub Release 的版本更新摘要，不负责产品介绍模板
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -98,20 +98,30 @@ function extractReleaseSection(source, version) {
     throw new Error(`Release version ${version} has an empty CHANGELOG.md section`);
   }
 
-  // ---- 双语内容合同：分类和条目由版本作者填写，不自动翻译或复制固定介绍 ----
-  const locales = [...body.matchAll(/^### ([^\r\n]+)[ \t]*$/gm)];
-  if (locales.length !== 2 || locales[0][1].trim() !== '中文'
-      || locales[1][1].trim() !== 'English'
-      || body.slice(0, locales[0]?.index).trim()) {
-    throw new Error('Release notes must be bilingual: ### 中文 first, then ### English');
+  // ---- 分类是源码语义，中文标题是发布显示；版本作者维护实际更新条目 ----
+  const labels = {
+    Added: '新增', Changed: '变更', Deprecated: '弃用',
+    Removed: '移除', Fixed: '修复', Security: '安全',
+  };
+  const categories = [...body.matchAll(/^### ([^\r\n]+)[ \t]*$/gm)];
+  const seen = new Set();
+  if (!categories.length || body.slice(0, categories[0].index).trim()) {
+    throw new Error('Release notes must start with a supported change category');
   }
-  const chinese = body.slice(locales[0].index + locales[0][0].length, locales[1].index);
-  const english = body.slice(locales[1].index + locales[1][0].length);
-  if (![chinese, english].every((section) => /^- [^\s].*$/m.test(section))) {
-    throw new Error('Each bilingual release section must contain non-empty change bullets');
+  for (const [index, category] of categories.entries()) {
+    const key = category[1].trim();
+    const content = body.slice(category.index + category[0].length,
+      categories[index + 1]?.index ?? body.length);
+    if (!Object.hasOwn(labels, key) || seen.has(key)) {
+      throw new Error('Release change category is unsupported or duplicated: ' + key);
+    }
+    seen.add(key);
+    if (!/^- [^\s].*$/m.test(content) || !/\p{Script=Han}/u.test(content)) {
+      throw new Error('Each release category must contain Chinese change bullets');
+    }
   }
-
-  return `${body}\n`;
+  return body.replace(/^### ([^\r\n]+)[ \t]*$/gm,
+    (_, category) => '### ' + labels[category.trim()]) + '\n';
 }
 
 function main() {

--- a/tools/extract_release_changelog.js
+++ b/tools/extract_release_changelog.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 依赖发布流程传入的内部 SemVer、CHANGELOG.md 与目标输出路径
- * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期、正文为空或缺少中文更新条目时失败关闭；保留 Added/Fixed 等源码分类语义，仅在发布投影为中文标题
+ * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期、正文为空或含非中文条目或列表之外内容时失败关闭；保留 Added/Fixed 等源码分类语义，仅在发布投影为中文标题
  * [POS]: tools 的 Release notes 内容边界，将内部版本真相源投影为 GitHub Release 的版本更新摘要，不负责产品介绍模板
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -116,8 +116,9 @@ function extractReleaseSection(source, version) {
       throw new Error('Release change category is unsupported or duplicated: ' + key);
     }
     seen.add(key);
-    if (!/^- [^\s].*$/m.test(content) || !/\p{Script=Han}/u.test(content)) {
-      throw new Error('Each release category must contain Chinese change bullets');
+    const bullets = content.split(/\r?\n/).filter((line) => line.trim());
+    if (!bullets.length || !bullets.every((line) => /^- [^\r\n]*\p{Script=Han}[^\r\n]*$/u.test(line))) {
+      throw new Error('Each release category must contain only plain Chinese change bullets');
     }
   }
   return body.replace(/^### ([^\r\n]+)[ \t]*$/gm,

--- a/tools/extract_release_changelog.js
+++ b/tools/extract_release_changelog.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * [INPUT]: 依赖发布流程传入的内部 SemVer、CHANGELOG.md 与目标输出路径
- * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期或正文为空时失败关闭
+ * [OUTPUT]: 对外提供精确版本 CHANGELOG 正文抽取，并在版本缺失、重复、未标日期、正文为空或缺少中文在前/英文在后的更新条目时失败关闭
  * [POS]: tools 的 Release notes 内容边界，将内部版本真相源投影为 GitHub Release 的版本更新摘要，不负责产品介绍模板
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -96,6 +96,19 @@ function extractReleaseSection(source, version) {
   const body = source.slice(selected.bodyStart, bodyEnd).trim();
   if (!body) {
     throw new Error(`Release version ${version} has an empty CHANGELOG.md section`);
+  }
+
+  // ---- 双语内容合同：分类和条目由版本作者填写，不自动翻译或复制固定介绍 ----
+  const locales = [...body.matchAll(/^### ([^\r\n]+)[ \t]*$/gm)];
+  if (locales.length !== 2 || locales[0][1].trim() !== '中文'
+      || locales[1][1].trim() !== 'English'
+      || body.slice(0, locales[0]?.index).trim()) {
+    throw new Error('Release notes must be bilingual: ### 中文 first, then ### English');
+  }
+  const chinese = body.slice(locales[0].index + locales[0][0].length, locales[1].index);
+  const english = body.slice(locales[1].index + locales[1][0].length);
+  if (![chinese, english].every((section) => /^- [^\s].*$/m.test(section))) {
+    throw new Error('Each bilingual release section must contain non-empty change bullets');
   }
 
   return `${body}\n`;


### PR DESCRIPTION
## 问题与行为
从 p8 开始，Release 的版本更新说明只显示中文，不额外显示“中文 / English”语言标题。分类语义与用户显示分离，避免重复两份更新内容。

## 改动
- CHANGELOG 保留 Added/Changed/Deprecated/Removed/Fixed/Security 英文分类键，版本条目写中文。
- 既有抽取器将分类键投影为新增/变更/弃用/移除/修复/安全；拒绝未知/重复分类、空条目及没有中文内容的分类。
- SOP 固定模板与 review 边界；p8 的中文条目同步回源，历史版本原文保持不变。
- 不改运行时、安装包、版本号或 CI workflow；未来 GitHub Release 与 updater notes 共用中文投影。

## 验证
- [x] tests-first 独立提交复现需求，先红后绿；六类映射、缺失/重复/空值/过期输出清除及当前版本抽取均通过。
- [x] Node contracts 284 passed；版本与 diff check 通过。
- [x] p8 正文已单独改为中文更新说明，未重打 tag、未替换 updater manifest 或安装器。
- [x] Issue #33 已 @Rwagsu 通知 p8 可直接更新当前语言。
- [x] 最终 564fb30 CI/ci_gate 与 Codex review 通过，合并提交 d941d66。

机器门只验证结构及中文内容存在，不冒充翻译/事实质量审查。p8 固定安装、安全、英日产品介绍段保留；只精简版本变化区块。
